### PR TITLE
build index by looking for missing run directories and not files

### DIFF
--- a/configurations/MOM_Run_Summary.ipynb
+++ b/configurations/MOM_Run_Summary.ipynb
@@ -17,9 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -72,34 +70,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Searching /g/data3/hh5/tmp/cosima/\n",
-      "Searching /g/data1/v45/APE-MOM\n",
-      "Found 38641 .nc files\n",
+      "Finding runs on disk...found 2590 run directories\n",
       "Using database sqlite:////g/data1/v45/cosima-cookbook/cosima-cookbook.db\n",
-      "Files already indexed: 38232\n",
-      "Files found but not yet indexed: 409\n",
-      "Indexing new .nc files...\n"
+      "Querying database...runs already indexed: 2733\n",
+      "11 new run directories found including...\n",
+      "/g/data3/hh5/tmp/cosima/mom01v5/KDS75_WOA13/output004\n",
+      "/g/data3/hh5/tmp/cosima/mom01v5/KDS75_WOA13/output003\n",
+      "/g/data3/hh5/tmp/cosima/mom01v5/KDS75_WOA13/output010\n",
+      "...\n",
+      "Finding files on disk...\n"
      ]
     },
     {
-     "ename": "ValueError",
-     "evalue": "No clients found\nStart an client and point it to the scheduler address\n  from distributed import Client\n  client = Client('ip-addr-of-scheduler:8786')\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-3-a15dd1d6c0d5>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mcc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbuild_index\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/cosima-cookbook/cosima_cookbook/netcdf_index.py\u001b[0m in \u001b[0;36mbuild_index\u001b[0;34m()\u001b[0m\n\u001b[1;32m    102\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    103\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Indexing new .nc files...'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 104\u001b[0;31m     \u001b[0;32mwith\u001b[0m \u001b[0mdistributed\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_client\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mclient\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    105\u001b[0m         \u001b[0mbag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdask\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbag\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_sequence\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfiles_to_add\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    106\u001b[0m         \u001b[0mbag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbag\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mindex_variables\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflatten\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/g/data3/hh5/public/apps/miniconda3/envs/analysis3/lib/python3.6/site-packages/distributed/client.py\u001b[0m in \u001b[0;36mdefault_client\u001b[0;34m(c)\u001b[0m\n\u001b[1;32m   3036\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3037\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3038\u001b[0;31m         raise ValueError(\"No clients found\\n\"\n\u001b[0m\u001b[1;32m   3039\u001b[0m                 \u001b[0;34m\"Start an client and point it to the scheduler address\\n\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3040\u001b[0m                 \u001b[0;34m\"  from distributed import Client\\n\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: No clients found\nStart an client and point it to the scheduler address\n  from distributed import Client\n  client = Client('ip-addr-of-scheduler:8786')\n"
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "302c803716c2443a948d0e9a7a370947",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another notebook frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=11), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Files found but not yet indexed: 0\n",
+      "Indexing new .nc files...\n",
+      "[########################################] | 100% Completed |  0.1s\n",
+      "Found 0 new variables\n",
+      "Saving results in database...\n",
+      "Indexing complete.\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -5531,7 +5570,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/cosima_cookbook/netcdf_index.py
+++ b/cosima_cookbook/netcdf_index.py
@@ -14,6 +14,7 @@ import distributed
 from distributed.diagnostics.progressbar import progress
 import xarray as xr
 import subprocess
+import tqdm
 
 directoriesToSearch = ['/g/data3/hh5/tmp/cosima/',
                        '/g/data1/v45/APE-MOM',
@@ -42,27 +43,69 @@ def build_index():
     # Build index of all NetCDF files found in directories to search.
 
     ncfiles = []
-    for directoryToSearch in directoriesToSearch:
-        print('Searching {}'.format(directoryToSearch))
-        results = subprocess.check_output(['find', directoryToSearch, '-name', '*.nc'])
-        results = [s for s in results.decode('utf-8').split()]
-        ncfiles.extend(results)
+    runs_available = []
 
-    print('Found {} .nc files'.format(len(ncfiles)))
+    print('Finding runs on disk...', end='')
+    for directoryToSearch in directoriesToSearch:
+        #print('Searching {}'.format(directoryToSearch))
+
+        # find all subdirectories
+        results = subprocess.check_output(['find', directoryToSearch, '-maxdepth', '3', '-type', 'd',
+            '-name', 'output???'])
+
+        results = [s for s in results.decode('utf-8').split()]
+        runs_available.extend(results)
+    print('found {} run directories'.format( len(runs_available)))
+
+    #ncfiles.extend(results)
+#
+#    results = subprocess.check_output(['find', directoryToSearch, '-name', '*.nc'])
+#
+#    print('Found {} .nc files'.format(len(ncfiles)))
 
     # We can persist this index by storing it in a sqlite database placed in a centrally available location.
 
     # The use of the `dataset` module hides the details of working with SQL directly.
+
     # In this database is a single table listing all variables in NetCDF4 seen previously.
     print('Using database {}'.format(database_url))
+    print('Querying database...', end='')
+
     db = dataset.connect(database_url)
 
-    files_already_seen = set([_['ncfile'] for _ in db['ncfiles'].distinct('ncfile')])
+    # find list of all run directories
+    r = db.query('SELECT DISTINCT rootdir, configuration, experiment, run FROM ncfiles')
 
-    print('Files already indexed: {}'.format(len(files_already_seen)))
+    runs_already_seen = [os.path.join(*row.values())
+                         for row in r]
+
+    print('runs already indexed: {}'.format(len(runs_already_seen)))
+
+    runs_to_index = list(set(runs_available) - set(runs_already_seen))
+
+    if len(runs_to_index) == 0:
+        print("No new runs found.")
+        return
+
+    print('{} new run directories found including...'.format(len(runs_to_index)))
+
+    for i in range(min(3, len(runs_to_index))):
+        print(runs_to_index[i])
+    if len(runs_to_index) > 3:
+        print('...')
+
+    print('Finding files on disk...')
+    ncfiles = []
+    for run in tqdm.tqdm_notebook(runs_to_index, leave=True):
+        results = subprocess.check_output(['find', run, '-name', '*.nc'])
+        results = [s for s in results.decode('utf-8').split()]
+
+        ncfiles.extend(results)
 
     # NetCDF files found on disk not seen before:
-    files_to_add = set(ncfiles) - set(files_already_seen)
+    #files_to_add = set(ncfiles) - set(files_already_seen)
+
+    files_to_add = ncfiles
 
     print('Files found but not yet indexed: {}'.format(len(files_to_add)))
 
@@ -75,7 +118,7 @@ def build_index():
 
     # determine general pattern for ncfile names
     find_basename_pattern = re.compile('(?P<root>[^\d]+)(?P<index>__\d+_\d+)?(?P<indexice>\.\d+\-\d+)?(?P<ext>\.nc)')
-    
+
     def index_variables(ncfile):
 
         matched = find_output.match(ncfile)
@@ -84,14 +127,14 @@ def build_index():
 
         if not os.path.exists(ncfile):
             return []
-        
+
         basename = os.path.basename(ncfile)
         m = find_basename_pattern.match(basename)
         if m is None:
             basename_pattern = basename
-        else: 
+        else:
             basename_pattern = m.group('root') + ('__\d+_\d+' if m.group('index') else '') + ('.\d+-\d+' if m.group('indexice') else '')+ m.group('ext')
-    
+
         try:
             with netCDF4.Dataset(ncfile) as ds:
                 ncvars = [ {'ncfile': ncfile,
@@ -112,14 +155,14 @@ def build_index():
         return ncvars
 
     print('Indexing new .nc files...')
-    
+
     with distributed.Client() as client:
         bag = dask.bag.from_sequence(files_to_add)
         bag = bag.map(index_variables).flatten()
-    
+
         futures = client.compute(bag)
         progress(futures, notebook=False)
-        
+
         ncvars = futures.result()
 
     print('')
@@ -137,24 +180,24 @@ def get_experiments(configuration):
     Returns list of all experiments for the given configuration
     """
     db = dataset.connect(database_url)
-    
+
     rows = db.query('SELECT DISTINCT experiment FROM ncfiles '
                 'WHERE configuration = "{configuration}" ORDER BY experiment'.format(configuration=configuration), )
     expts = [row['experiment'] for row in rows]
-    
+
     return expts
 
-def get_nc_variable(expt, ncfile, 
+def get_nc_variable(expt, ncfile,
                     variable, chunks={}, n=None,
                     op=None,
                     time_units="days since 1900-01-01"):
     """
-    For a given experiment, concatenate together 
+    For a given experiment, concatenate together
     variable over all time given a basename ncfile.
 
     Since some NetCDF4 files have trailing integers (e.g. ocean_123_456.nc)
     ncfile is actually an regular expression.
-    
+
     By default, xarray is set to use the same chunking pattern that is
     stored in the ncfile. This can be overwritten by passing in a dictionary
     chunks or setting chunks=None for no chunking (load directly into memory).
@@ -188,7 +231,7 @@ def get_nc_variable(expt, ncfile,
 
     if len(ncfiles) == 0:
         raise ValueError("No variable {} found for {} in {}".format(variable, expt, ncfile))
-    
+
     #print('Found {} ncfiles'.format(len(ncfiles)))
 
     dimensions = eval(rows[0]['dimensions'])
@@ -212,13 +255,13 @@ def get_nc_variable(expt, ncfile,
         op = lambda x: x
 
     #print ('Opening {} ncfiles...'.format(len(ncfiles)))
-    
+
     dataarrays = []
     for ncfile in ncfiles:
         dataarray = xr.open_dataset(ncfile, chunks=chunks, decode_times=False)[variable]
-        
+
         dataarray = op(dataarray)
-        
+
         if 'time' in dataarray.coords:
             if time_units is None:
                 time_units = dataarray.time.units
@@ -229,7 +272,7 @@ def get_nc_variable(expt, ncfile,
                                    )
 
         dataarrays.append(dataarray)
-        
+
     #b = dask.bag.from_sequence(ncfiles)
     #b = b.map(lambda fn : op(xr.open_dataset(fn, chunks=chunks,
     #                                         decode_times=False)[variable]) )
@@ -237,7 +280,7 @@ def get_nc_variable(expt, ncfile,
     #dataarrays = b.compute()
 
     #print ('Building dataarray.')
-    
+
     dataarray = xr.concat(dataarrays, dim='time', coords='all', )
 
     #if 'time' in dataarray.coords:
@@ -250,16 +293,16 @@ def get_nc_variable(expt, ncfile,
     #                               )
 
     #print ('Dataarray constructed.')
-    
+
     return dataarray
 
 def get_scalar_variables(configuration):
     db = dataset.connect(database_url)
-    
+
     rows = db.query('SELECT DISTINCT variable FROM ncfiles '
          'WHERE basename = "ocean_scalar.nc" '
          'AND dimensions = "(\'time\', \'scalar_axis\')" '
          'AND configuration = "{configuration}"'.format(configuration=configuration))
     variables = [row['variable'] for row in rows]
-    
+
     return variables


### PR DESCRIPTION
As the number of .nc files has grown, the time taking to find new files to add the database was getting frustratingly long.  This change checks the run directories (e.g. output123). If the directory does not yet exist in the database, only then are the files enumerated.

