### PR TITLE
Changed cachedir so as not to interfere between users

### DIFF
--- a/cosima_cookbook/memory.py
+++ b/cosima_cookbook/memory.py
@@ -9,6 +9,13 @@ from ..memory import memory
 
 from joblib import Memory
 
+import os, getpass, tempfile
+
+username = getpass.getuser()
+
+
+
 # pick up cachedir from an environment variable?
-cachedir='/tmp'
+# Append username to prevent clashes with others users
+cachedir = os.path.join(tempfile.gettempdir(),username)
 memory = Memory(cachedir=cachedir, verbose=0)


### PR DESCRIPTION
I have tested this lightly:

```python
>>> import cosima_cookbook
netcdf_index loaded.
>>> cosima_cookbook.memory.cachedir 
'/short/v45/aph502/tmp/aph502'
```

It should work, though it will lose all current cache information, and will require users to reinstall cosima_cookbook via `pip`