### PR TITLE
TAO data comparison at 140W, 0N

### DIFF
--- a/ContributedExamples/plot_TAO_140W_0N.ipynb
+++ b/ContributedExamples/plot_TAO_140W_0N.ipynb
@@ -1,0 +1,328 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "source": [
+    "# Comparison of EUC/TC structure at 140W, 0N to TAO data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/g/data3/hh5/public/apps/miniconda3/envs/analysis3-18.04/lib/python3.6/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
+      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/g/data3/hh5/public/apps/miniconda3/envs/analysis3-18.04/lib/python3.6/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
+      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "netcdf_index loaded.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "import cosima_cookbook as cc\n",
+    "import matplotlib.pyplot as plt\n",
+    "from mpl_toolkits.basemap import Basemap, shiftgrid\n",
+    "import numpy as np\n",
+    "import netCDF4 as nc\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/g/data3/hh5/public/apps/miniconda3/envs/analysis3-18.04/lib/python3.6/site-packages/ipykernel/__main__.py:3: DeprecationWarning: The 'cachedir' parameter has been deprecated in version 0.12 and will be removed in version 0.14.\n",
+      "You provided \"cachedir='/g/data1/v45/cosima-cookbook/'\", use \"location=None\" instead.\n",
+      "  app.launch_new_instance()\n"
+     ]
+    }
+   ],
+   "source": [
+    "from joblib import Memory\n",
+    "\n",
+    "memory = Memory(cachedir='/g/data1/v45/cosima-cookbook/', verbose=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['mom025_jra_ryf0304',\n 'mom025_jra_ryf8485',\n 'mom025_jra_ryf9091',\n 'mom025_jra_ryf9091_saltunderice',\n 'mom025_nyf',\n 'mom025_nyf_salt']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#configuration = 'mom01v5'\n",
+    "configuration = 'mom025'\n",
+    "\n",
+    "expts = cc.get_experiments(configuration)\n",
+    "display(expts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 218,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ncfile = 'ocean.nc'\n",
+    "#expt = 'mom025_jra_ryf8485'\n",
+    "expt = 'KDS75_newbathy_JRA' "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 219,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='get_nc_variable:', max=9), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='get_nc_variable:', max=9), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    }
+   ],
+   "source": [
+    "temp = cc.get_nc_variable(expt, ncfile, 'temp',\n",
+    "                        chunks={'st_ocean': None}, n=9,\n",
+    "                        time_units=\"days since 1900-01-01\")\n",
+    "\n",
+    "u = cc.get_nc_variable(expt, ncfile, 'u',\n",
+    "                        chunks={'st_ocean': None}, n=9,\n",
+    "                        time_units=\"days since 1900-01-01\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 220,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Extract 140W, 0N:\n",
+    "temp_140w0n = temp.sel(st_ocean=slice(0,300)).sel(yt_ocean=0.,method='nearest').sel(xt_ocean=-140.,method='nearest')\n",
+    "u_140w0n = u.sel(st_ocean=slice(0,300)).sel(yu_ocean=0.,method='nearest').sel(xu_ocean=-140.,method='nearest')\n",
+    "dep = u_140w0n.st_ocean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 221,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Get TAO data:\n",
+    "obs_file_temp = xr.open_dataset('/g/data/e14/rmh561/TAO/t0n140w_dy.cdf')\n",
+    "obs_temp = obs_file_temp['T_20'].isel(lon=0).isel(lat=0).sel(depth=slice(0,300))\n",
+    "obs_temp = obs_temp.where(obs_temp!=1.e35)\n",
+    "count = np.count_nonzero(~np.isnan(obs_temp), axis=0)\n",
+    "obs_temp = obs_temp.isel(depth=count>=5000) # Only average if more than x observations at given depth\n",
+    "obs_file_u = xr.open_dataset('/g/data/e14/rmh561/TAO/adcp0n140w_dy.cdf')\n",
+    "obs_u = obs_file_u['u_1205'].isel(lon=0).isel(lat=0).sel(depth=slice(0,300))/100.\n",
+    "obs_u = obs_u.where(abs(obs_u)<=100.)\n",
+    "count = np.count_nonzero(~np.isnan(obs_u), axis=0)\n",
+    "obs_u = obs_u.isel(depth=count>=5000)  # Only average if more than x observations at given depth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 222,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f280989dac8>"
+      ]
+     },
+     "execution_count": 222,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": [
+       "iVBORw0KGgoAAAANSUhEUgAAAnIAAAFMCAYAAABPtlHVAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd8jdcfwPHPzSA2Qa2YESsiZu3RovaI0aKqRmnVik1bao+fUautojWrwwhiq1GhRkvN0FC1Ys9Eybzn98eRS9KESG5yR77v1yuv5N773Oc5h5yT7z3POd9jUEophBBCCCGEzXGwdAGEEEIIIUTSSCAnhBBCCGGjJJATQgghhLBREsgJIYQQQtgoCeSEEEIIIWyUBHJCCCGEEDbKJgO5rVu3UqpUKUqUKMHUqVMtXRwhhEg06b+EEOZksLU8ckajkRIlSrBz507y589PlSpV+PHHHylVqpSliyaEEC8k/ZcQwtxsbkTu8OHDeHh4ULhwYZydnenQoQPr16+3dLGEEOKlpP8SQpibzQVywcHBFCxY0PTYzc2N4OBgC5ZICCESR/ovIYS5OVm6AK8qvjvBBoMhUc8JIeybtc8Ukf5LCPEiSenDbG5Ezs3NjcuXL5seX716lfz588d7rFIq1b4+//xzuZ5cz6qvmeLX27YNBfrL2ZnPe/RI8NgqVaoAcODAAbNd3xakVv81ceJEcuTIYTqXo6MjgwcP5t9//7XO3x0bL481lknKY1vlUSrpfZjNBXJVqlTh/PnzXLp0iYiICH788Udatmxp6WIJIa5c0d8NBihTBnLnTvDQiIgIANKnT58aJbMaqdV/ffLJJ1y/fp21a9fi4+ODUooZM2bg5eXFsWPHzH49IYTl2Fwg5+joyLx583jrrbfw9PSkQ4cOlC5d2tLFEkJs3Ki/f/wxBATAC4K00NBQADJnzpwaJbMaqdl/pU+fHh8fH9auXcvBgwcpV64cFy5coEaNGvz8888pck0hROqzuTlyAI0bN+avv/6ydDFiqVevnlxPrmfV10zR6925Axs26J937Xrp9R48eABA9uzZU65MVsoS/VeVKlU4dOgQH3/8MYsXL+add97hxo0b9O/fP1Hvt0T7eBFrKw9YX5mkPC9mbeVJDpvLI5dYBoMhWfechRCv4Oef4Z139M/OzrB3L1SrFu+hRqMRJycnlFJERETg7OxsliLYU5tPqboopZg+fTrDhg0DYMKECXz66admv44Q4tUltd3b5IhcchQpUoRLly5ZuhhCvJLChQtz8eJFSxcjYdmyPfu5TBnw9Ezw0IcPH6KUImvWrGYL4kTiGAwGhg4dSu7cuenevTufffYZSik+++wzSxdNCJFEaS6Qu3Tpkt18ahdph9WnowgJ0d/r1gV/f8iSJcFD7969C0DOnDlTo2QiHl27dsXJyYn333+fUaNGkSlTJgYOHGjpYgkhksDmFjsIIaxQzCh38eIvDOJAAjlr0blzZ7777jsABg0aZPpZCGFbJJATQiRPaCj873/6540b9eMXuHfvHgCurq4pXTLxEu+//z5z5swBoFevXmzatMnCJRJCvCoJ5IQQyXPqlF61CnD3Lpw+/cLDYwI5GZGzDv369ePTTz8lOjqa9u3bc/jwYUsXSQjxCiSQE0IkT5kyOgkwQIkSL1zoAM8Cued3HhCWNX78eLp168aTJ09o0aKFdS+sEULEIoGcsGpLly6ldu3aZjvf2LFjee+998x2PgFcvw5Go97J4eDBl86Ru3//PiCBnDUxGAx88803NGjQgFu3btGsWTNTrj8hhHWTQM6KFC1alF1Pk6kC/Pjjj+TMmZO9e/fi4OBA1qxZyZo1K/ny5aNly5b88ssvsd6/b98+atasSfbs2cmVKxe1a9fmyJEjAEyePJksWbKYzpExY0acnJxMoyNdu3Ylffr0ZM2a1XSctazuTeqKzV9//ZWCBQua7XwJ6datG6NHjwb0qujn/6+KFSvG1KlT431fvXr1cHV1JTIy0qzlSXWHDunvtWq9NIiDtJ0M2Jo5OzuzevVqPD09CQwM5O2337b9300h0gAJ5KzU0qVL6devH5s3b6Zw4cIYDAYePnxISEgIx48fp0GDBvj4+LBs2TJAb3nUokULBgwYwP379wkODubzzz837WU5cuRIQkNDCQkJISQkhOHDh5sCCdDBzfDhwwkJCTEdZ/UpL15CKWWROjz/f7Vq1SrGjx/Pzp07Yx1z6dIl9u3bh4ODAxtidkSwVTFzqqpWTdThMiJnvbJly8amTZt47bXX2LFjB3379rWaD3RCiPhJIGeFFixYwNChQ9m+fTtVn/vjGNOhvvbaa/Tv358xY8YwfPhwAIKCgjAYDLz99tsYDAbSp09PgwYNKFu2bLzXWL58OV27dk1WOWNGvGbOnEmePHkoUKAAS5YsMb0eERHBkCFDKFy4MPny5aN3796Eh4cDejTKz88PwBTQbN26FYCdO3dSoUIF03mMRiP9+/cne/bslClTJtao5ZIlSyhTpgxZs2alePHiLFiwAIDHjx/TtGlTrl27ZhphvHHjBgDh4eG8//77ZM2aFS8vL44ePQrA9OnTadeuXaw69uvXj0GDBr3yv03M/1WlSpXw9PT8z0bly5Yto3r16nTt2jXWv5lNihmRe8VATkbkrFPhwoVZv349Li4uLFiwgOnTp1u6SEKIF5BA7jkGg8FsX0n11Vdf8fnnn7Nr165YwUx82rRpw82bN/nrr78oUaIEjo6OdO3ala1bt75wfsvevXu5desWbdq0+c+1c+XKRZUqVVi7dm2iynvjxg1CQ0O5du0aixYtok+fPjx8+BCAYcOGcf78eU6cOMH58+e5du0a48aNA6Bu3brs2bMHgICAANzd3fn1119N5Xt+H7xDhw5RvHhx7t69y5gxY2jTpo2pfnny5GHz5s2EhISwePFiBg4cyLFjx8iYMSNbtmwhf/78phHGvHnzAuDv70+nTp14+PAhLVq0oE+fPoDOq7Vt2zZCnia3jY6O5ueff6ZLly6J+rd4Xkwgd/DgQU6fPk3x4sVjvb5s2TI6d+5Mp06d2LZtG7dv337la1iFJ0/g+HFwcIDKlRP1lpj/OxmRs17VqlVj+fLlgG7HP//8s4VLJIRIkLJTCVXtRVUGzPaVFEWKFFHZsmVTrVu3jvX8xYsXlYODg4qOjo71fFhYmDIYDOq3335TSil19uxZ1a1bN1WwYEHl7OysWrZsqW7duvWf6/To0UN169Yt1nN//vmnunfvnoqOjlabN29WWbJkMZ03IXv27FEZM2aMVa7XXntNHTp0SCmlVKZMmdSFCxdMr/3222+qaNGiSimldu7cqby9vZVSSjVu3Fh9++23qnr16kopperWrav8/PyUUkotWbJEFShQINZ1X3/9dbVixYp4y9S6dWs1Z84cU/kKFiwY6/UxY8aohg0bmh4HBgaqjBkzmh43bdpULVq0SCmllL+/v/L09Hzhv4FSSnXt2lWNGjVKKaX/rwwGg8qRI4fKkCGDcnBwUEOHDo11fEBAgEqXLp26d++eUkqp0qVLq1mzZr3wGlbbVLdvVwqUKlMm0W8pV66cAtTRo0fNWhSr/TdKAmupy7Rp0xSg0qdPr/bu3Wvp4ghh15La7mVE7jlKKbN9JdX8+fMJCgqiR48eLz02ODgYeJZYtWTJknz33XdcvnyZU6dOce3aNXx9fWO9JywsjFWrVv3ntmr58uXJkSMHDg4ONGnShHfffTdRo3I5c+bEweHZr1HGjBl59OgRt2/f5vHjx1SqVAlXV1dcXV1p0qSJKat/9erVCQoK4tatWxw/fpwuXbpw5coV7t69y+HDh6lTp47pnAUKFIh1zcKFC3Pt2jUAtmzZQvXq1cmZMyc5cuRgy5Yt3InJaZaAmJG5mPKGhYVhNBoB6NKlCytWrADg+++/T9IKV4PBwN27d/n333+ZPn06e/bsISoqyvT6smXLeOutt0wjUh07dmTp0qWvfB2LCw2FmN+jGzdemgg4hsyRsx2DBw/m448/Jjw8nObNm/Pnn39aukhCiDgkkLMyr732Gjt37iQgIICPP/74hceuXbuWPHnyULJkyf+8VqJECbp27cqpU6diPb9mzRpy5swZK1CKj8FgSFZAmitXLjJmzMjp06e5d+8e9+7d48GDB6bbrhkyZKBSpUrMnj2bsmXL4uTkRPXq1Zk5cybFixePlfU/JmCNcfnyZfLnz09ERATt2rVj2LBh3L59m/v379OkSRNTuZNyi7t169acOHGC06dPs3HjRt59990k1V89XWgxcOBA0qdPz1dffQXoQPrnn3/m119/JV++fOTLl49Zs2Zx/PhxTp48maRrWcypU/A0oObhw5cmAo4hW3TZDoPBwJw5c2jfvj0hISE0atSIoKAgSxdLCPEcCeSsUN68edm1axfbtm1j8ODBALFG+m7dusW8efMYP348U6ZMAeCvv/5i5syZpqDnypUr/PDDD1SvXj3WuZctWxbvnK81a9bw77//opRi+/btfP/997Rq1SrJdTAYDPTs2RNfX1/T/K/g4GC2b99uOqZOnTrMmzePunXrAnoBxPOPY9y8eZO5c+cSFRXFqlWrOHv2LM2aNSMiIoKIiAhy5cqFg4MDW7ZsiXX+PHnycPfuXdOct4Q8H7CmT5+etm3b0qlTJ6pWrYqbm9sr1z1uADxixAimTp1KREQEfn5+ODk5cebMGY4fP87x48c5c+YMtWvXtr1Ruee32Cpd+qWJgEEHso8fP8bZ2ZnMmTOnYOGEuTg6OrJixQreeustbt++TcOGDblw4YKliyWEeEoCOSvy/AiSm5sbO3fuZPXq1XzyyScYDAZy5MhBlixZKFeuHFu3bmX16tW8//77AGTJkoVDhw5RtWpVsmTJQo0aNShXrlysFWfXrl1j9+7d8QZys2fPxs3NjRw5cjB8+HAWLVqUpES8z9dhypQpFC9enGrVqpE9e3beeuutWJ/m69aty6NHj0yjgzGP4wZy1apV49y5c+TKlYtRo0axZs0asmfPTubMmU2jBa6urvz444+xgs+SJUvSsWNHihUrhqurq2nV6ovKDHr/yZMnT77SIofnzxH3fM2aNcPV1ZWFCxeyfPlyunfvToECBXjttddMX3369GHlypWmW7w2YcsW/b1uXfjtt0TlkIu57Z0zZ06bT2+TlqRLl461a9dSo0YNLl++TJ06dWRkTggrYVDJuX9mxRK6NZjcW4bC/l25coXSpUtz48aNRI0atW3blrp169K/f/8UK5NV/t6+/jr8/jssWQJPP1C8zJ9//knFihUpV64cx48fN2txrPLfKImstS6hoaE0a9aMgIAA8uTJw86dO/FMxEisEOLlktruZUROiOcYjUZmzJhBhw4dEhXEBQcHs2/fPionMvWG3ThzRgdxADNmJHqhw61btwDInTt3SpVMpKAsWbKwZcsW6tevz82bN6lXr55p9xghhGVIICdeKO7WXjFfzZo1s3TRzO7x48dky5aNXbt2MXbs2Fivxfdv4OjoSKFChejRowc1atSwUKktZPHiZz+fPZvohQ43b94E9KIeYZsyZcqEv78/TZs25c6dO9SpUwd/f39LF0uINMvJ0gUQ1m3kyJGMHDnS0sVIFRkzZiQ0gZGlhJ5Ps2JW2Do6QpkyiVroAJjmKebLly+lSiZSQYYMGfDz86NXr14sXbqU1q1bM3v2bPr27WvpogmR5siInBDi1Tx5Ak934WDdOggISNRCB4Dr168DEsjZg3Tp0rF48WLGjRuH0WikX79+DBw4kOjo6P8eHBICBw4k+ha8ECLxJJATQrya3bt1MFepEjRvnuggDiSQszcGg4FRo0axfPlynJ2dmTVrFs2bNzflCgTg/n3Ikwdq1dK/My9JBySEeDUSyAkhXs3Gjfp7EuZJXrlyBYCCBQuas0TCwjp37sz27dvJlSsXW7dupVKlSs8WQaxcCWFhYDTCuXNQoQJMm/YsmbQQIlkkkBNCJJ5SsGmT/rl581d++6VLlwAoVKiQOUslrEC9evU4evQor7/+OpcuXaJmzZosWrQI3nsPPDzAwUHPqbxwAYYNg4IFoXFjHeg9fmzp4gthsySPnBA2wGp+b0+ehHLl9K2ya9f0H+dEioyMJH369BgMBsLCwnB2djZr0azm38gMbLku4eHh+Pr6Mn/+fAC6d+/OvMmTyXDhgg7o9u2DZcvA3x8iI/WbsmSB9u11PsJatV7p90oIeyF55IQQKS9mNK5p01f+Y3v16lWUUuTPn9/sQZywHunTp+frr79m6dKluLi48N1331Gxbl3+cHKCnDmhVStYswauX4d583Ri6dBQ+O47vUtI8eIwYgSsWiWLI4RIBAnkrMTzecocHR3JmDGj6bkffvjBdNySJUtwcHBg9erV/znHw4cP6d27N/ny5SNz5sx4e3uzZMmSVKyFsHvJmB8Xsz9nsWLFzFkiYaW6dOnCwYMHKVWqFGfPnqVatWqMHTuWyJhRuJw5oU8fOHQIAgNh5Ehwc4N//oGpU+Htt/XI79SpOugTQsRLAjkrERoaSkhICCEhIRQuXJhNmzaZnuvYsaPpuGXLlpEzZ87/bLAeGRlJ/fr1uXLlCocOHeLhw4f873//Y8SIEcyaNSu1qyPs0d27OoWEszM0bPjKbz9//jwA7u7u5i6ZsFLe3t4cPXoUX19foqOjGTNmDDVr1uTs2bOxDyxdGiZNgosXYc4ciNmH98kTPTpXoAC8+SYsXAj37qV6PYSwZhLIPS80NPm5jsxwDqVUvPfJL126xN69e1mwYAHbtm3j9u3bpteWLVvG1atXWb16NYUKFcLR0ZFGjRoxZ84cRo0axaNHj5JcHiEA2LpVrzysUweyZn3lt//999+ABHJpTYYMGfjiiy/YuXMnBQsW5Pfff6dChQrMmTMHo9EY+2BHR+jaVc/DdHaGQoX06K+zs05706sX5M0LLVroRRLSrwkhgZxJaKj+41Sjhv5uMCTtK+YctWubfX7HsmXLqFy5Mj4+PpQqVYrvv//e9Novv/xCkyZNcHFxifWetm3bEhYWxoEDB8xaFpEGJWO1Kkggl9a9+eabnDx5kvfff5+wsDAGDBhAvXr1CAwMjH1gliw6yfTevXDqlL6df/OmnkPXsCFER+vn3n1X33rt0AHWr4fwcMtUTAgLk0AuxqlT5j1fYGCi959MrOXLl/Puu+8C0KlTp1i3V+/cuRNvklVHR0dy5crFnTt3zFoWkcZERcHmzfrnunWTdIqY22keHh7mKpWwMdmyZWPJkiWsXbuW3LlzExAQgLe3N5988gmPn09BkiULVKv2LNl09uzQrRts365XS8+dqz8wP34MP/0ErVvrkbouXWD2bJ2EWIg0QgK5GGXLgre3HsL39tbZx5V6ta+QkGfneIX9JxNj//79/PPPP7zzzjsAdOzYkRMnTnDixAkAcuXKZcqa/7zo6Gju3LlDrly5zFYWkQZt2wYPH+qfu3V75dHmiIgIgoKCMBgMlC5dOgUKKGyJj48PZ8+e5cMPPyQqKorJkyfj6enJpphR3xfJkwf69oX9+/WcuilTdL/74AEsXw6+vpA7N/TooW/HxrdlmBB2RAK5GM8P57/C3pFmP0cCYkbfypcvT758+ahWrRoGg4Fly5YB0KBBA7Zs2cKTJ09ivW/16tW4uLhQrVo1s5VFpEELFjz7OQmjzefPnycqKoqiRYuSMWNGMxdO2CJXV1fmz5/PgQMH8Pb25uLFizRv3py2bdty9erVxJ2kcGEYPhyOHdNz5mJS4kRH61uxb76pV8L266fz18WdkyeEHZBA7nlxh/MtdY44wsPDWbVqFQsXLuTYsWMcP36c48ePM2fOHFasWIHRaOS9997Dzc2N9u3bc+nSJaKioti2bRsDBgxg7NixZDFjeUQaExGhP5wAODklabT59NPAz9OMo9TCPlSrVo0//viDmTNnkjlzZtauXUvp0qWZOXPms1QlidG8OXh56TsiJUrAoEFQrBjcuKHz1dWurRdPDBwIBw/quyhC2AEJ5KyQIWbp/VPr1q0jY8aMvPfee7z22mumrx49emA0Gtm6dSvp0qXjl19+oWDBglStWpVs2bIxZMgQJk+ezKBBgyxUE2EX/Pz0bauSJfVIcxJGm2MCuTJlyqRECYWNc3JyYuDAgZw5c4a2bdvy6NEjBg8ejJeXFxs2bEhctvvn74j88QfMmAHnz8Pvv8PQoTqICw6GWbOgenUoWlRvFXbkiJ4Wk9yMBUJYiGzRJYQNsNjvbWio3hPz4UM9mTwoKEmjza1bt2b9+vWsXLkyVl5Ec7Kntm1PdUmKzZs34+vry7lz5wB44403mDFjBhUqVEj6SZXSyYd/+knvGhEc/Oy1dOn0gh53dx0EJiG9jhDJJVt0CSHMb+vWZ4sc7txJ8krsY8eOAXqOpxAv07RpU06dOsXs2bNxdXVl9+7dVKpUia5duxL8fAD2KgwGPe3liy/g8mU9cte3L+TIoacPGI1w7pweeR4yRN9+lTl1wgZYZSA3duxY3NzcqFixIhUrVmTr1q2m1yZPnoyHhwelS5dm+/btFiylEGnAmjX6u4ODnheXhDlu9+7d49KlS2TIkIESJUqYuYDWR/ov80iXLh39+/fn/PnzDB48GCcnJ5YuXYqHhwejR49OXpJzBwc9Z27uXLhwQY/EOTjoOaA3bujbstWr68UUvr6yUEJYN2WFxowZo2bMmPGf5wMDA1X58uVVZGSk+ueff5S7u7syGo3xniOhqllplYV4IYv83p46pZTBoJSTk1Jr1yoVEpKk0+zatUsBqmrVqmYuYGzW0rZTsv9Ky86fP6/atWunAAWovHnzqoULF6qoqKjknzwkRKkDB5R68ECpgAClfH2VcnOLnWAqXz6l+vRRavdupcxxTSHiSGq7t8oROSDe+8Tr16+nQ4cOODk5UaRIETw8PDh8+LAFSidEGjB6tP4T1qsX+PgkeSX2n3/+CZC8+U02Rvov83N3d2fVqlXs27ePqlWrcuPGDXr27Em5cuVYs2bNf7f7ehUx2QayZYNatfTt10uX9O3VIUOgSBG4fh2+/BLeeAPy54cPP9Q7SgQEyCIJYVFWG8h9+eWXlC9fng8++ICHT+foBAcHU7BgQdMxBQoUSPp8CSFEwo4cgbVrwcUFPv00WaeKCVYqVapkjpLZBOm/Uk7NmjU5cOAAP/zwA0WKFCEwMJB27dpRuXJlNm3aZL5FIg4OULUqTJumb7/+8QeMGAHFi8OtWzq3YuvWeu/hwoXhxx8hTh5PIVKDk6Uu3LBhQ27evGl6rJTCYDAwceJEPv74Y0aPHo3BYOCzzz5j8ODBLFq0KMFVqAkZM2aM6ed69epRr149c1ZBCPv12Wf6e9++evQhGQ4ePAhg9qTUe/bsYc+ePWY9Z2JJ/2VZBoOBDh060KZNG7799lsmTJjAn3/+SfPmzalWrRoTJkzgzTfffOG/7yteECpV0l+TJsHJkzqNyeLF+vX796FjR8iYEZo00SPYzZrprcWESIDZ+jBz3dtNKRcvXlReXl5KKaUmT56spkyZYnqtUaNG6uDBg/G+L6GqFS5c2DTHQr7ky1a+ChcubPa2laCAAD0nKEsWpW7fTtaprl27pgCVJUsW88xlegGwvu7M3P2XiN/jx4/VzJkzVe7cuU1tpl69eiogICDlLhoSopS3t55DmjevUhUrxp5T5+ysVKNGSn3zjVI3bqRcOYTdSGq7t8re4vr166afZ86cqTp27KiUUur06dOqfPnyKjw8XF24cEEmCwthbkajUnXq6D9Eo0cn+3R+fn4KUPXr1zdD4V7MWtq89F+WExoaqiZNmqSyZ89uCugaN26sfv/995S5YMwiiZiFQJcvKzVnjlL16inl4PAsqDMYlKpVS6kZM5S6cCFlyiJsnl0Fcu+9957y8vJS3t7eqlWrVurGc59mJk2apNzd3VWpUqXUtm3bEjyHdIRCJMG2bfoPT44cegVfMg0fPlwB6tNPPzVD4V7MWtq89F+Wd//+fTV69GiVOXNmU0DXunVrdezYsdQrxK1bSn37rVLNmyuVLl3s0TovL6U++ECp/fv1hychVNLbfZrb2UEIkQCl4PXX9aTuKVP0ZuTJVLt2bfbt28eGDRto0aKFGQqZMHtq8/ZUF0u6c+cO06ZNY+7cuTx5uhChcePGDBkyxLxz6F4mNBS2bNHb3W3cCM/nwCtUSC+aaNVK57Zzdk6dMgmrk9R2L4GcEEJbt05P0s6TB/7+GzJlStbpHjx4QK5cuQD9BzV7Ck/8tqc2b091sQY3btxg8uTJLFq0iMePHwM6Hc7QoUNp3749Tk6puO7v11+hfn2Ijv7va9mzQ9OmOqhr3Fi2CktjZIsuIUTSRUfDqFH6508/TXYQB7Bjxw6io6OpVatWigdxQrxI3rx5mT17NpcvX2b8+PG89tpr/Pnnn3Tq1Al3d3dmzZpFaGrlgqtYEcqW1SNv5crBL7/otCalS8ODB7ByJbzzDuTKpYO5r7+Gq1dTp2zCJsmInBACvv0WPvgA3Nzg/HlInz7Zp+zWrRtLlixh6tSpDBs2zAyFfDF7avP2VBdrFBYWxvLly5k+fTpBQUEAZM+enY8++oj+/fuTL1++lC1AaKjet9jTM3ai7XPndJLhDRtg//7Y24JVqqRH6ho00NMgvLySnKRbWCe5tRqHdIRCJNI//0CpUnrjcDc3CAxM9h8Io9FI/vz5uXnzJidPnqRs2bJmKmzC7KnN21NdrJnRaMTf35/p06ezb98+QO/x+u677zJkyBDKlCljucLdvg2bNunAbvt2eHpL2CRXLp3HrlEjmVdnJySQi0M6QiES4dQpaNhQbxQO+g/C3r16u6JkOHLkCJUrV6ZQoUJcvHgxVSaV21Obt6e62IqDBw8yffp01q5da/q3b9asGUOGDKFu3bqptzAiPk+ewM6dejcJf//Yr+XIoZMPt2qlgzoZpbNZMkdOCPFqNm+GGjV0EJchgw7iypTRt3uSaePGjQA0bdrUsn8AhUikatWqsXr1aoKCgujduzcuLi5s2rSJN954g8qVK7Nw4cLUm0cXV4YM0Lw5fP+9nlfn5AS5c4OHh95VYsV0zbZhAAAgAElEQVQKaN9ej9I1bQrffKP3hhVpgozICZHWKKW3FxoyRM/BeecdmDNH7ycZd85OEkRGRuLu7s6VK1fYsmULjRs3NlPBX8ye2rw91cVW3b59m6+++op58+Zx584dADJnzsy7775Lr169qFixomUKFnd+XVCQvv26bh0cOKDbd4yqVfVIXatWejGFfKiyanJrNQ7pCIWIR0SE3j914UL9+PPP9ZcZO/gffviBTp06UbJkSQIDA3FwSJ2Bf3tq8/ZUF1v35MkT1qxZwzfffGOaRwdQqVIlevXqRceOHcliLbczb97UeerWr4cdOyAs7NlrxYvrgK5hQ70q3dtbbsNaGQnk4pCOUIg47t2Dtm1hzx5wcdETpTt0MOsllFJUrlyZo0ePsmDBAnr27GnW87+IPbV5e6qLPQkMDGThwoUsXbqU+/fvA3qUrlOnTvTq1YtKlSpZuITP+fdfHcytX6/n1d29G/t1V1eYPx9atND9gbA4CeTikI5QiOf89ZeeY3P+POTNqzv31183+2X27NnDG2+8Qe7cubl8+TIuqfgHwp7avD3VxR6FhYWZRukCAgJMz1esWJEPP/zQukbpAKKi4LffdE66H3+M/VrmzNCkiU4G3rQpZMtmmTIKCeTiko5QiKd++QXatYOHD6F8eZ2jqmDBFLlUixYt2LhxI2PGjOHzzz9PkWskxJ7avD3Vxd6dOXOGBQsWxBqly5Qpk2mUrnLlyhYu4XNCQ6FWLZ1iKGdOeO01OHny2evOznrXiZgtw/LmtVxZ0yAJ5OKQjlAI9Cfwfv30zg2tW8Py5foTeAo4e/YspUuXxsXFhcuXL5M7d+4UuU5C7KnN21Nd0oqYUboFCxawd+9e0/MVK1Y0zaXLag1bbsVdLHHxol4o4ecH+/Y9S0JsMED16rrfiNm679QpvSuFNY022hEJ5OKQjlCkaVFRMGgQzJ2rH48YARMnQgouPOjatStLly7lww8/ZP78+Sl2nYTYU5u3p7qkRWfOnDHNpbt37x6gR+l8fHxo164db731FhkyZLBwKeNx+7aeT+fnp+fXhYc/ey19eoiM1Ismfv9d9oFNARLIxSEdoUizHj7UKUW2bdO3ShYuhPffT9FLLly4kF69euHk5MTp06cpUaJEil4vPvbU5u2pLmlZWFgYa9eu5Ztvvok1SpcpUyaaNWtGmzZtaNasGZlTaJQ8WUJDdR/i56dH7J7fWaJQId2ntG+vR+gkrYlZSCAXh3SEIk36+2+9Cu3MGZ0c1M9Pz4lJQTt27KBJkyZER0ezaNEievTokaLXS4g9tXl7qovQzp07x+rVq1mzZg1HjhwxPZ8+fXoaNWpE27ZtadGiBTly5LBgKRNw9y5UqQKXLumgLTr62WulSumAToK6ZJNALg7pCEWas3cvtGmjO11PT32LpGjRFL3k6dOnqVGjBiEhIQwfPpwpU6ak6PVexJ7avD3VRfzXxYsXWbt2LWvWrOG3334zPe/k5ET9+vVp27YtrVu3TvV5pi8UM7euZEn44w9YtQrWro2d1iQmqHv7bd0HSVD3SiSQi0M6QpGmLF4MH36o57A0aaJTDKTwHJabN29StWpVLl26RLt27fjpp59SLflvfOypzdtTXcSLXbt2DT8/P9asWcOvv/6K8eliAwcHB+rUqUPbtm1p06YN+fPnt3BJ4xEZqfNSJhTUvf22TmkSHQ1eXrJI4iUkkItDOkKRJkRH64UM06frx76+MG2a3osxBT158oQ33niDQ4cO8frrr7Nnzx6LT962pzZvT3URiXf79m3Wr1/PmjVr2LlzJ5GRkabXqlevTtu2bWnbti1FihSxXCETEhPU/fyzntIRNwFx3rywa5feKkzESwK5OKQjFHYvNBQ6d9Z54ZycYN48PSqXwoxGI++88w6rV6+mcOHCHDp0iDx58qT4dV/Gntq8PdVFJM2DBw/w9/dnzZo1bNu2jbDnttuqWLGiKagrWbKkBUuZgMhI2L1b90n+/rFfq18funTR00CscZGHBUkgF4d0hMKuXboELVvCiROQIwesXg1vvpkqlx45ciRTpkwha9as/Pbbb3h6eqbKdV/Gntq8PdVFJN+jR4/YvHkza9euZdOmTTx69Mj0mqenpymo8/LywmBN89KeT0CcKRM8eaL3ewb9uG1bHdTVqweOjhYtqjWQQC4O6QiF3Tp4UGddv3ULSpTQn3hTId3H5cuXGTduHN9++y2Ojo5s2bKFhg0bpvh1E8ue2rw91UWY15MnT9ixYwdr1qxhw4YNPHjwwPRawYIFqVOnDrVr16ZOnTqUKlXK8oHd8wmIo6P1rddly2D//mfHuLnpuwtduqTpW68SyMUhHaGwS99+C71761sX9evrScYpnK7gxo0bTJ48mfnz5xMREYGDgwMLFiywWJqRhNhTm7enuoiUExERwe7du1mzZg3r1q3j9u3bsV7PlSuXKairXbs23t7eOKXw/NlEO39e7zSzbJneXSJGlSp6kUTZslCzZppaICGBXBzSEQq78uiR3mpryRL9OGdOCAoCV9cUu+S9e/f43//+x9y5c3n8NBlohw4dGDNmjFXOy7GnNm9PdRGpw2g0cvr0afbu3UtAQAB79+7l+vXrsY7JkiULNWvWNAV3VapUIX369BYq8VNGox6dW7ZMj9aFhDx7zdVV33GoUcNy5UtFEsjFIR2hsBsHDsB77+lkvzGcnXXeuGrVzH65kJAQZs2axYwZMwh52qm2bNmS8ePHU65cObNfz1zsqc3bU12EZSil+Pvvv01BXUBAAH8/34egkxFXrVrVNGJXvXp1slhyBOzJE73qfswYeP73v25d/UG2VasUX5FvSRLIxSEdobB5kZEwbhxMmqQ/tXp66uf++QfKlIGAALPednjy5AlffvklU6ZM4e7T1AENGzZk/PjxVK1a1WzXSSn21ObtqS7CegQHBxMQEGAK7k6dOhXrdUdHRypUqECdOnWoU6cOtWrVImfOnKlbyNBQqF1bz6vLlg3CwuDff/VrBQtCnz7wwQf6roSdkUAuDukIhU07c0aPwh05orOjDx2qg7qIiGcTh80UxEVERLBo0SImTJhguhVTs2ZNJk6cSN26dc1yjdRgT23enuoirNfdu3fZv3+/acTuyJEjRD+//RZ6Vezz8+zc3NxSvmDPL5BQCpYuhblz4dw5/bqLi14c0a+f3r3m1Ck9p87G59NJIBeHdITCJhmNOvfS8OH6k2jhwnruSJ06Zr9UVFQUy5cvZ+zYsVy6dAnQ+akmTJhA48aNLb/a7RXZU5u3p7oI2/Ho0SMOHDhgGrE7dOhQrPx1AEWLFo21MrZ48eKp01cYjbBtG8yZA1u3Pns+UybdV3p6wr59Nh3MSSAXh3SEwuZcvQrdusEvv+jHXbvC7Nlm32rLaDSyatUqPv/8c/766y8AypQpw7hx42jTpo3NBXAx7KnN21NdhO0KDw/njz/+MI3Y7du3j9DQ0FjH5M2bN9aInZeXV8pv1ffXX/Dll7BokZ5XB/rOxVdfwUcfpey1U5AEcnFIRyhsyk8/6Q7owQM992PBAp353IyMRiP+/v58/vnnHD9+HIBixYoxduxYOnbsiKONJ+S0pzZvT3UR9iM6Oprjx4/HWkARN+VJ9uzZqVWrFrVr1+att97C29s75T4cBgfrdCXPr85t3BgmTIBKlVLmmilIArk4pCMUNuH+fejbF1au1I+bNtW54vLmNdslQkNDWbJkCXPnzuXc0zkmbm5ujBo1im7duuHs7Gy2a1mSPbV5e6qLsF9KKf766y9TYLd3714uX74c65iiRYvSunVrfHx8qFGjhvk/MIaGwuHD+k7Gl1/qxwDt2ul5xTaUYFgCuTikIxRW75df9O3T4GDImBFmzoRevfQtAjO4cOECc+fO5bvvvjOlESlcuDADBw7kww8/xMXFxSzXsRb21ObtqS4ibbl06RIBAQHs2bMHf39/bt26ZXotd+7ctGzZEh8fH+rXr2/+PujOHZg6Vc8zDgsDBwe9W8TgwTrAs/IFERLIxSEdobBaT57AyJF6/htA1ao6w7mHR7JPrZRiz549zJ49mw0bNpjaQO3atfH19aVly5bWk9ndzOypzdtTXUTaFR0dzcGDB/Hz88PPz48LFy6YXsucOTNNmzbFx8eHpk2bktWcc4GDg/Xt1UWLICpKP+fgoAM5K14QIYFcHNIRCqt09KheNn/mjE5sOXq0DuqSGVyFhYWxcuVKZs+ezYkTJwBIly4dHTt2ZMCAAVSoUMEcpbdq9tTm7akuQoD+kHny5EnWrVuHn58fx44dM73m7OxM/fr18fHxoVWrVuTJk8c8F/37b513btu2Z8/9/DO0b2+e85uZBHJxSEcorEpUFPzvf/D55/rnkiVhxQqoXDlZp7127RpfffUV33zzDXfu3AEgT5489O7dm48++sh8HaINsKc2b091ESI+//zzjymo27dvn+n33WAwUKNGDXx8fGjdujXu7u7Ju1BoKFSo8GxnnAwZ9N2QDz4w2zQWc5FALg7pCIXV+PtvPU/jt9/04379YMoUPS8uiQ4fPszs2bP5+eefiXp666BSpUoMGDCAt99+2/L7J1qAPbV5e6qLEC9z69Yt/P398fPzY8eOHURERJhe8/LywsfHBx8fn6SvgA0NhYMHdTaA1av1c61awcKFkDu3mWqRfBLIxSEdobA4pfQKVF9fvcVM/vyweDG89VaSThcZGcnatWuZNWsWBw8eBMDBwYE2bdrg6+tLjRo1bDYHnDnYU5u3p7oI8SpCQ0PZsmULfn5+bNq0KVbeuiJFiphWwNasWTNpK2BXroTevSEkRAdxI0ZAz55WMW9OArk4pCMUFnXzpu4c/P3147ffhq+/BlfXVz7V3bt3WbBgAV9++SXBwcEA5MiRg549e9KnTx8KFSpkzpLbLHtq8/ZUFyGSKjw8nN27d+Pn58f69eu5efOm6bVkrYC9dAk6dXp2l6RgQb0lmIWDuSS3e2Uhq1atUp6ensrBwUEdOXIk1muTJk1SxYsXV6VKlVLbtm0zPb9lyxZVsmRJ5eHhoaZMmfLC81uwaiKtW7dOqdy5lQKlsmVT6vvvlTIaX/k0J0+eVD179lQuLi4KUIAqXbq0+vrrr9WjR49SoOC2LbXbfEr2YdJ/CRFbVFSU2rdvnxoyZIhyd3c39YmAypw5s2rfvr1auXKlevDgQeJOGBCglIOD7qdBqUmTUrYCiZDUdm+x3uLs2bMqKChIvfHGG7E6wcDAQFW+fHkVGRmp/vnnH+Xu7q6MRqOKjo5W7u7u6uLFiyoiIkJ5e3urM2fOJHh+6QhFqgsJUapHj2cdw5tvKnX58iudIioqSq1bt07Vr18/VkfVpEkTtW3bNmVMQkCYVqR2m0/JPkz6LyESZjQa1YkTJ9TYsWNV+fLlY/WVzs7OqnPnziokJOTFJwkJUcrb+1kw5+Sk1ObNqVOBBCS13VssoVTJkiVBlzrW8+vXr6dDhw44OTlRpEgRPDw8OHz4MEopPDw8KFy4MAAdOnRg/fr1lCpVKtXLLkQsoaF63sXkyXrIPn16vZihf3+duygR7ty5w7fffstXX31lyoyeKVMmunbtSr9+/UztRVgP6cOEsAyDwYCXlxdeXl6MHj2aixcvxloBu2LFCk6ePIm/vz8FCxaM/yRZskBAAJw6pTMIfPWV3hZx7VrInt3qkwc/z+oygwYHB1O9enXT4wIFChAcHIxSKtZ/iJubG4cPH7ZEEYV45vp18PaGmP0Gvbzghx/A0zNRbz9y5Ajz5s3jhx9+IDw8HIDixYvTp08funbtSvbs2VOq5CKFSB8mROoqUqQIvr6++Pr6EhQURIsWLTh+/Divv/46/v7+VE4ozVOWLFC9OlSrBhEROoFw8+b6A7inpw70bCCYS9FArmHDhrEmJyqlMBgMTJw4kRYtWsT7nrifbkFH30ajMd7nX2TMmDGmn+vVq0e9evUSV3AhXkYpPQrn66u3hQHd+L/88qVBXHh4OKtXr2bevHmm1acGg4FmzZrRt29f3nrrLRwSOZKXlu3Zs4c9e/ak6DUs2YdJ/yXEqytRogQHDhygbdu27Nmzhzp16rBixQratGmT8JsMBpg/X99R2bEDjEYIDNQLIKpVS7GymqsPS9FAbseOHa/8Hjc3N65cuWJ6fPXqVfLnz49SKtZmvDHPv8jzHaEQZvPHH/q26YED+nGGDBAZqQO48uUTfNvVq1f55ptvWLBggWn/wezZs9OjRw969+6d/MSXaUzc4Gbs2LFmv4Yl+zDpv4RIGldXV7Zt20bv3r357rvvaNu2LVOmTGHYsGEJf3hydISlS/UK1uhoKFQo0XdWkspsfZgZ5uclS7169dQff/xhenz69GlVvnx5FR4eri5cuGCaKBwVFWWaKBweHq68vb1VYGBggue1gqoJe3PjhlLduytlMOjJsXnyKPXdd0o9eKDUgQN68mwcRqNR7dmzR7Vr1045OjqaJuSWK1dOLVy4UP37778WqIh9slSbT4k+TPovIZLPaDSqKVOmmPrd7t27q/Dw8Be/acQI3b83aJA6hXxOUtu9xXoLPz8/5ebmplxcXFTevHlV48aNTa9NmjRJubu7x7t0v0SJEqp48eJq8uTJLzy/dITCbMLDlZo2TaksWXQDd3ZWasgQpR4+TPAtjx49UvPnz1dly5Y1dSJOTk7q7bffVgEBAbL6NAWkdptPyT5M+i8hzGfNmjUqQ4YMClD16tVTd+/eTfjgO3eUypRJ9/WLF8f7AT2lJLXdS0JgIV5k0yYYOBDOndOPmzWDmTOhRIl4Dz937hxfffUVixcv5uHDh4De+/TDDz+kV69eFChQILVKnubYU5u3p7oIYQ3++OMPWrRowY0bNyhRogQbN27Ew8Mj/oP79tXznQ0GKFcu1RY9JLXdy4xqIeLz11/QtKlewXTunN7kfvNm2LjxP0Gc0Whk8+bNNGnShBIlSjBr1iwePnxIjRo1WLlyJZcvX2bs2LESxAkhhIVUrlyZw4cP4+3tTVBQENWqVePXX3+N/2Bvb/1dqWeLHqyYBHJCPO/hQxg8WOcQ2rIFsmaFGTPgxAlo0iTWoffv32fmzJl4eHjQrFkztm7diouLC927d+fIkSPs37+fjh07ki5dOgtVRgghRIyCBQuyb98+mjdvzr1792jYsCFLliz574HPLzwrUybFFz0kl9xaFQL0KqUlS+CTT+DWLT2k3qMHTJwIr70W69CTJ08yd+5cVqxYwZMnTwCdx+jjjz+me/fu5MyZ0wIVEPbU5u2pLkJYm+joaIYOHcoXX3wBwMiRI5kwYcKztE+//QY1a+oA7sCBVMsll9R2b3UJgYVIdfv363QiR4/qxzVrwuzZUKlSrMMCAgKYMmUKmzdvNj3XsGFD+vbtS7NmzXB0dEzNUgshhEgCR0dH092Ujz/+mMmTJ1O7dm2axNx1icn5aCP5PCWQE2nX1aswbJjeiQGgQAGYNg06dNAjcujkrps3b2by5Mns378fgAwZMtC9e3f69u0r2ysJIYSNikn2nSNHDsqVK/fshevX9feTJ6F2bavf4UECOZH2PHmi571NngyPH+u9UYcNg+HDIVMmAKKioli1ahVTpkzhxIkTgE7e269fP/r370+uXLksWQMhhBDJsGHDBsaOHYvBYOCHH36IvRjtu++e/ZwKOzwklwRyIu1QSm+IPGQIXLyon2vbFqZPhyJFAAgLC2PJkiVMmzaNCxcuAJAvXz4GDx5Mr169yGLFn8qEEEK83NmzZ+ncuTMAkyZNolGjRs9eDAmBmG2znJxsYrGDBHIibTh5EgYMgN279WMvLz0P7o03AAgJCeHrr7/miy++MA23Fy9enGHDhtGlSxfSp09vqZILIYQwk5CQEHx8fAgNDaVdu3YMHz489gHLlkFYGFStCrNm6SDOyj/Ay6pVYd/u3oXRo/WGyEYjuLrChAnQsyc4OXHr1i1mz57Nl19+aUrgW758eUaOHEnbtm1lAYMNsac2b091EcJaGI1G2rZty7p16/D09OTgwYNkzpz52QEhIZAvn55yU7CgvqWaikGcrFoV4nlRUTp4Gz0a7t/XGyL37Qtjx4KrKxcvXmT69Ol8++23hIWFAVC3bl1GjBhBo0aNEt5YWQghhE2aNGkS69atI3v27Kxbty52EAcwfrwO4gBu3LD6uXExZERO2J9du/Rt1FOn9OP69fUQedmynD59milTpvDDDz8QHR0NQIsWLRg5ciTVq1e3YKFFctlTm7enughhDTZt2kSLFi0A2LhxI02bNo19wO+/69RTkZH6g3/Zsqm+WlW26BLin3+gTRsduJ06BUWLgp8f7NjBwUePaNWqFWXLlmXFihUAdO7cmZMnT7JhwwYJ4oQQwk4FBQXRqVMnlFKMHz/+v0HcvXvQvr0O4nr2hH37rD7lyPNkRE7YvuvXYeRInQ8uIkKnEPnkE9TAgWzfu5fJkyeb9tRzcXGhR48eDB48mKJFi1q44MKc7KnN21NdhLCk0NBQqlWrRmBgID4+PqxevfrZDg6gt2Vs2lTv5lClig7gLLS4TebIibRp3Tr9SSoqSj9+5x2i//c/1h46xJRatTj6dLeGrFmz0qdPHwYMGECePHksWGAhhBCpQSlF165dCQwMpHTp0ixdujR2EBcSAh4ecPu23sVh8WKLBXHJIYGcsE2PHsHQoXpBw1PKyYnNHh4MbNCAc+fOAZAnTx4GDhzIRx99RLZs2SxVWiGEEKkoMjKSUaNGsXbtWrJmzYqfn1/sPKBK6duot2/rxw4OEBpqmcImk9xaFbZn717o1g0uXAAnJ1SuXBhv3+ackxNVwsN5BBQtWpShQ4fStWtXMmTIYOkSi1RgT23enuoiRGr79ddf6du3L6eeLnjbsGGDaaEDoFNR9e0LX3+tHzs56XxxFp4XJ4sdhP178gQGD4Z69XQQV748h776ijcLFKBmdDRVwsPJVaQIS5cuJSgoiN69e0sQJ4QQacS1a9d49913qVevHqdOnaJYsWKxVqsCEB2tR+K+/lrfRl21SgdwNrS4IS4ZkRO24fBheP99OHsWHB0J7tqVD/75h627dgH6Fupnn31Gr169SJcunYULKyzBntq8PdVFiJQWGRnJnDlzGDNmDI8ePcLFxYWRI0cybNgwXFxcnj8QOneGn38GFxfw94cGDSxX8DiS2u4THcj9+++/uLi42Eyme+kI7UREBIwbpze4NxoJd3dndKFC/O/pVlvZsmVj2LBhDBgwgExPN7wXadPL2rwt9WHSfwmROLt376Zv374EBgYC0KpVK7744ov/ZiW4cUOnpzpwQD92d4c//7SqUTizB3JGo5Eff/yR77//nt9//5306dMTHh5O7ty5adq0Kb169cLDwyPZBU8p0hHagePHoUsXOHECZTCw1dOTtqdP80QpXFxc6N+/P8OHD8fV1dXSJRVWIG6bt+U+TPovIV7s6tWrDBkyhJ9++gkAd3d35syZ898ccaDzwr39tk5VFcPZWc+3tqKdG8weyNWtW5cGDRqYkqjGLNm9d+8eu3fvZuXKlfj4+NC5c+fklTyFSEdow6KiYOpUvZ1WZCR3smWj/b//sicqCicnJz744ANGjRpF/vz5LV1SYUXitnlb7sOk/xIifhEREcyaNYtx48bx77//kiFDBj799FMGDx4c+zYq6JWpc+bAkCH670qNGvDgAZw7B2XKWN28OLMHcpGRkTg7O7/wzYk5xlKkI7RRZ87ouXC//w7AAmdnBkVG8i/QsWNHxo0bR/HixS1bRmGV4rZ5W+7DpP8S4r9++eUX+vXrx9mzZwFo06YNM2fOpHDhwv89+Pp1eO892LlTPx48WE/RCQvTe6h6elpVEAcpPEfu/v37XLlyhaiYpKtAxYoVX/liqUk6QhsTHQ2zZ6M++QRDeDhXHRzoajSyE2jWrBkTJ07E29vb0qUUVuxFbd7W+jDpv4R45sqVKwwaNIjVq1cD4OHhwdy5c2nUqFH8b/jtN3jzTQgPf5bot0uXVCxx0qTYzg6jRo1iyZIluLu7YzAYTBfb9XS1oBDJ9vffqK5dMezbhwH4DhhoNFKuVi0CJk+mVq1ali6hsGHShwlhm8LDw5k5cyYTJkzg8ePHZMyYkc8++4xBgwaRPr4dGCIjYcoUPS0nOlo/5+AAJUqkbsFT2UtH5EqWLMnJkydtLqWDfKK1AUph/PprjIMG4RQeznWgJ3DV25tJkybRpEkT0x9eIV4moTZvi32Y9F8irdu+fTv9+vUjKCgIgHbt2jFjxgwKFSoU/xtOndLTcp5uy0jOnHoLLiucC5eQFEsIXLZsWR48eJCkQgmREHX5MncqV8ahTx+cwsP5AWhRpAjvrlzJ0aNHadq0qQRxwiykDxPCdly+fJm2bdvSqFEjgoKCKFmyJDt27GDVqlXxB3FRUTBpElSsqIO4QoXgl1/gn3/0qlQbCeKS46Ujcn/88Ydp1dfzQ5kbNmxI8cIlh3yitVJK8ffo0eSZPJnM0dHcAT7NkYOKkyfTvXt3q5x4LmxDQm3eFvsw6b9EWhMeHs706dOZOHEiT548IVOmTIwePRpfX9+ER9N//13PfXu6+IFevWDaNMiaNfUKbkYpttjB09OTDz/8EC8vL9PyfdBL+62ZdITW5+7p01xo2JAqT3P5bHZ25sLw4XQfOZKMGTNauHTC1iXU5m2xD5P+S6QlmzdvZsCAAZw/fx6Ad955h+nTp+Pm5hb/G8LC9Dy4KVP0YycnvdVW69apVOKUkWKLHTJmzEj//v2TVCghYpwZM4a848ZRRSkeAL+0aEGDpUtpmiOHpYsm7Jz0YUJYp7///puBAwfi7+8PQJkyZZg7dy5vvvlmwm/65Rf4+GOdCy6GwQB586Zwaa3XS0fkYlaHtGzZMtZtCWteug/yidZaGG/d4myDBpQ5eRKAw9myUWDrVgpYUTZtYY9/8j4AACAASURBVB8SavO22IdJ/yXs2ePHj5k8eTLTpk0jPDycLFmyMGbMGPr165fw9JqbN2HQIFi5Uj8uUUKvTL182aYWNLxIit1afeONN+K9mLUv3ZeO0PIeLFuGsWdPXCMieATsaNSI5hs24GxDqweF7UiozdtiHyb9l7BHSinWrFnDoEGDuHLlCgBdunRh6tSp5E1oRM1ohAULYMQIePhQb3Y/erRO8BsebrXJfZMiRRMC2yLpCC0oNJQbPj7kfZpR+zcnJyIXLKBut24WLpiwZ/bU5u2pLkIABAYG0q9fP9MHqAoVKjBv3jxq1KiR8Jv279cLGAID9eMmTWDePChWLBVKnPrMnn5kxYoVGI3GBN/4999/s2/fvle+oLBv0Tdvcq1ECfLu3IkCbqdLR5ETJySIE6lO+jAhLO/hw4cMGjQIb29vdu3ahaurK/Pnz+f3339POIi7fRu6d4datXQQ5+QEy5bBpk12G8QlR4KLHe7evUuFChWoVKkSlSpVInfu3ISFhXH+/Hl+/fVXcuXKxZSYFSNCALeOHuVJ7doUfvwYI/pTQi6lMDx8aOmiiTRI+jAhLMdoNLJ8+XKGDx/OzZs3MRgMfPTRR0yYMIGcOXPG/6bISPjySxgzRt9GjWEwgIeH/i7+44W3VqOjo9m1axf79+/n+vXrZMiQgdKlS9OkSZOEsytbCbk1kbr2L1lCwR49KGQ08peDAwXc3Mh8/brdTEIV1i++Nm+rfZj0X8KWHT16lL59+3LgwAEAatSowdy5c1+8wGjbNvD1fZYTrn59uHoVLlxIM39HZI5cHNIRpo6oqCjm9+5Nu0WLyAsEZs2K64ED5C1Y0K4moQrrZ09t3p7qItKOu3fv8umnn7JgwQKUUuTJk4dp06bRuXPn+HfqCQ2FLVtgyRL9HaB4cfjiC2jWDB49SlN/RySQi0M6wpQXHBzMpGbNmHj8ONmBv93dKXLkCI7Zslm6aCINsqc2b091EfYvOjqaBQsW8Omnn3L//n2cnJwYMGAAo0ePJmtCuyxcvaq31bp9Wz/OnFmvRu3fH55LE5SWSCAXh3SEKWvr1q0sfucdFoeEkBG4Xbs2uXfsSLMNUFiePbV5e6qLsG/79++nb9++HDt2DIAGDRowZ84cSpcuHf8boqJg0SIYORJi9kB2cIANG/QoXBpm9lWrKW316tWULVsWR0dHjh49anr+0qVLZMyYkYoVK1KxYkU+/vhj02tHjx6lXLlylChRAl9fX0sUO82LjIxkxIgRLG7ShOVPg7gnHTqQe9cuCeJEmiJ9mEjLrl+/TpcuXahVqxbHjh2jUKFCrF69mu3btyccxO3YARUqQO/eOojLmFGvSPXygjp1UrcCduSlW3SFh4ezZs0aLl68SFRUlOn50aNHJ+vCXl5e+Pn58eGHH/7nteLFi8fqGGP07t2bRYsW8frrr9O0aVO2bdtGo0aNklUOkXiXL1+mY8eOeP72Gz+gPwWogQPJMGOGrCYSVkv6MCHMJyIigjlz5jBu3DhCQ0NJnz49w4YNY8SIEQnvmf3XXzBkCGzcqB8XKaI3t3/rLZ1eJI3MgUspLw3kWrVqRbZs2ahUqVKs7W2Sq2TJkgDxDiPG99yNGzcIDQ3l9ddfB3Q26HXr1kknmEr8/f3p2rUrH9y7x9SYJydMwPDJJxLECasmfZgQ5rFjxw769+/P2acrS1u2bMkXX3xBsYRyu126BMOGwZo1ejutLFng009hwAC9QwOAbNeYbC8N5K5evcrWrVtToywmFy9epFKlSmTNmpXx48dTq1YtgoODcXNzMx3j5uZGcHBwqpYrLTIajQwfPpzp06czBRgOKIMBw7x5euNiIayc9GFCJM+VK1fw9fVl7dq1AHh4eDB79myaNGkS/xsiI/XK008+0QEcwPvvw9SpkCdPKpU67XhpIFejRg1OnjyJl5fXK5+8YcOG3Lx50/RYKYXBYGDixIm0aNEi3vfkz5+fy5cvkyNHDo4ePUrr1q0JDAyM9xNuvMuZnzNmzBjTz/Xq1aNevXqvXIe0LCoqiu7du/P98uUsMBjoqRTKyQnD0qXQqZOliyfSuD179rBnz56XHmerfZj0X8LSoqOj+frrrxk5ciSPHj0iU6ZMjBo1Cl9f3/hHt5UCf38YOhSCgp497+QEH30kQVwcie3DXibBQM7LywuDwUBUVBSLFy+mWLFipE+f3tSRnThx4qUn37FjxysXyNnZmRw5cgBQsWJF3N3dCQoKws3NzbTJLuhP2fnz53/huZ7vCMWriYyM5L333mPtTz+xytGRNtHR4OKCYfXqNL+ySFiHuMHN2LFjY71u632Y9F/Ckk6dOkXPnj05ePAgAD4+PsyZMyfWqHIsf/6pN7LfvVs/9vDQK1SvXtUJfT09U6nktuNlfVhiJRjIbYyZlJgKnv+keufOHVxdXXFwcODChQucP3+eYsWKkT17drJmzcrhw4epUqUKy5Yto3///qlWxrQkPDycDh06sH3dOjY7OtIgOhqyZtWftGRlkbAR0ocJ8erCwsKY8P/27ju+pvt/4PjrZogVIkaMKIqQJcsINWLFKEXj26J+1VJao1UdRr8oSuk0WlRVjS7zq2itULFqJ7SVqMSOEUGQIvvz++M0l5BERO49uTfv5+PxfXxzT849n/fRcz55n/NZkyfz0UcfkZaWRpUqVZg9ezY9evTI/gsXLsDYsdqkvkqBs7O2xNZrr0FSUpGa0Fc36iH69u2bp22PavXq1crV1VUVL15cVa5cWXXs2FEppdSqVauUp6en8vX1VQEBAerXX381fufgwYPKy8tL1alTR73xxhu5Hj8PpyaycefOHdW5c2dVFtReW1ulQKmKFZU6dEjv0ITIVU73vCXWYVJ/CT2EhYUpNzc3BShADR48WF2/fj37nf/5R6n33lPKwUH7O2Fvr9Rbbyl17Zp5g7Yi+b3vHzohsL+/f5Zh9Onp6Xh7exMZGWnC9PLxyYSaj+727dt069aNP7ZsYYutLd7p6VC9ujb3z78j9IQorHK65y2xDpP6S5hTQkICI0eO5JtvvgHA3d2d+fPn89RTTz24c0YGfPedNqHvxYvatjJlYPt28PU1Y9TWp8AnBJ46dSqOjo788ccflClTBkdHRxwdHalUqRLdunV7rGBF4ZOYmEinTp2I3rKFPZlJnJsb7NolSZywSFKHCZE7pRQrVqzA3d2db775hmLFijFhwgQiIiKyT+K2bYOGDeGll+4mcQB37mjNqEIXD30jN2bMGKZOnWqueAqMPNHm3Y0bN+jUqRPX9+xhq40NVTIytNm3N26ESpX0Dk+IPMnpnrfEOkzqL2Fq586dY8iQIca+pM2bN+frr7/OflWG48e1+eDWrNE+V6umrYs6ezZERWmDGXbulH5wj8lka60qpVi9ejW7du3CYDDQokULunfvnu9AzUUqwry5du2aNiHpwYNssrHBOSNDG9Cwdi2ULat3eELkWU73vCXWYVJ/CVNJT09nzpw5vPfee/zzzz+UKVOGjz/+mIEDB2Jjc08jXWIi7N6tJW/ffKONQC1VCkaPhrfe0pbXSkyUwQwFyGSJ3JAhQ4iJiaF3794ALFu2jNq1azN79uz8RWomUhE+XHx8PO3bt6fckSOsMxgorZQ2tciKFVCihN7hCfFIcrrnLbEOk/pLmMKff/7JwIED2bdvHwDPPvssX3zxxYPT4Fy9Cg0aaCNSM73yCkyaBFWqmDHiosVkiVz9+vWJiooyTlyZkZGBp6cnUVFR+YvUTKQizN2lS5do27YtdSIjWW4w4KCUNsnvokVgb693eEI8spzueUusw6T+EgXp/ilFqlatyuzZsx98M62U1hozdChkrjpiMMCSJdC3r/kDL2IKfLBDpjp16nD27Fnj53PnzlGnTp1HLkgUHrGxsbRq1YqAyEhWgZbEDRmijUSSJE5YGanDRFEWFhZGgwYNmDJlCunp6QwZMoTIyMgHk7gjR6BtW+jeXUviHBy0FRm8vUEGBxVqD12iKzExEXd3dxo3bozBYGD//v00bNiQZ555BoC1a9eaPEhRcE6fPk2bNm3ocuoUszI3jh2rvTJ/yJJnQlgiqcNEUZSQkMC7777LggULAPDw8GD+/Pk0a9Ys646XLsG4cbBgQdYJfV94QRvkIP3fCr2HNq1u37491wO0atWqQAMqKNI08aCYmBjatmnDS+fOYVwI5LPPtI6rQli4nO55S6zDpP4S+ZU5pcgbb7xBXFwcxYoV47///S+jRo3Kuj5qfLw28vS77+DWLe3t27BhWlLn7KzfCRRhJusjB3DmzBmio6Np164dd+7cIS0tDcdCnqFLRZjVsWPHaNemDe9evMhwQNnYYJg/H/r31zs0IQpEbve8pdVhUn+J/Dh79ixDhw41TinSokULvv76a+rXr393J6Xg++9hwABITdW2deoE06fLnKE6M1kfufnz59OzZ09effVVQOtfVdiH7ous/vrrL9q0bMmUzCSuWDEMK1ZIEieKBKnDhLVLT09n1qxZeHp68ssvv1C2bFnmzZtHWFhY1iTu8GFo3RpefPFuEmdnp72ZkyTOYj00kZs9eza7d++mTJkyANStW5fLly+bPDBRMGJiYujQqhVz4+PpB6hSpTD8+is8+6zeoQlhFlKHCWt27tw5WrZsyfDhw/nnn38ICQkhKiqKQYMG3Z0X7vJlGDQI/P21pbScnbVJfe3ttT5wnp76noR4LA8d7ODg4ECxYsWMn9PS0ozD+EXhlp6ezuC+ffnu2jXaAKpcOQwbNkCTJnqHJoTZSB0mrFVoaCi9e/fm6tWrVK1alTlz5txdfi4xESIiYMcO+OQTuHlTe/v2+uvaGzhbW5nM10o8NJFr1aoVH374IXfu3CE0NJQ5c+bQtWtXc8QmHtPcyZOZsm8fjYEMFxdstmwBLy+9wxLCrKQOE9YmIyODqVOnMm7cOJRSdOjQgR9++IHy5ctrO9y8CT4+cPr03S917gyff561CTUw0KxxC9N46GCHjIwMFixYwObNm40XzCuvvFLon2iLemfh49u2kda2LR5KcdvFhZK//w5PPql3WEKYTE73vCXWYUW9/hI5S0hIoF+/fqxbtw6DwcD48eMZN24ctra22g7HjmmL2v+7egOgJXAjRugSr8g7k45ajY+PB6BixYqPHplOinJFmHbsGJd9fKiakkJsuXK4/vUX3L8EixBWJrd73tLqsKJcf4mcHT58mJCQEE6ePEm5cuX44Ycf6NSpk/bLGze0+UBnzdLWRbWx0eYG9fSEXbuk+dQCFPioVaUUEyZMoEKFCtSvX5969epRsWJFJk2a9FiBChM7coSkRo2ompJCeLFilAkPlyROFElShwlrsmjRIpo2bcrJkyfx9/fn0KFDWhKXkQHffgtubtqbt/R0bWBDTIyWwEkSZ/VyTORmzJjB7t27OXDgAFevXuXatWvs27eP3bt3M336dHPGKPLq999Ja9GC0v/8QyhwY+VKytSsqXdUQuhC6jBhDZKSknj11Vd5+eWXSUpKYsCAAezevZtaFSrA119Dw4banHCXL8NTT8HBgzBvHtSqpfWBkyTO6uXYtOrn50doaCgVKlTIsj0+Pp7g4GAiIiLMEmB+FbmmiU2bUD16YLhzh1XA9kGDmDVvnt5RCWE299/zllyHFbn6S2TrzJkz9OzZk4MHD+Lg4MDs2bMZMGAAnDgBjRpBQoK2Y5Uq8Omn0Lu3LLVowfJ73+c4ajU1NfWBChC0PiapmRMJisJh+XLo2xdDairfAtNq1SL8s8/0jkoIXUkdJizZpk2b6NOnD9euXaNmzZqsWrUK/wYNtD5wY8bA7dvajjY22koNbdroG7DQTY5Nq/fOu/QovxNmNn8+9OoFqalMNxh4BViweDGlS5fWOzIhdCV1mLBEGRkZTJo0iU6dOnHt2jU6d+7MoUOH8L91CwICYPhwLYlzdNTmhfP21t7OiSIrx6ZVW1tbSpUq9cB2pRRJSUmF/om2SDRNfPwxjBoFwMyKFXkzPp4RI0bw+eef6xyYEOZ3/z1vyXVYkai/xAOuXbtG37592bBhAwaDgYkTJ/LfAQOwGT1aW9weoGZNmDkTgoIgMlIm9LUiJp1+xBJZdUWoFLz1FsyYAcD/2rYlZOtW6tWrR0REBCVKlNA5QCHMz5rueWs6F5E34eHhhISEcPr0aZydnVk+bx5td+3SRqQmJoKDg/bgPno0SB1vlSSRu49VV4QzZhgnd0xycaFSXBy3bGz4/fffaSLLb4kiyprueWs6F/FwCxYsYOjQoSQnJ9OwYUN+efNNXF55BZKStB06doQvv4TatfUNVJiUJHL3sdqK8J9/4IknjKOVUoCWQJsxY/jwww91DU0IPVnTPW9N5yJylpSUxLBhw1iwYAEAI158kY9tbbFbuPDuTnZ2sHOnLKdVBBT4qFVRSM2YoSVxJUqQmpxMZEYGeHjw/vvv6x2ZEEKIPDp16hQ9e/YkPDyc4g4OhPbtS/M1a+DKFS15c3bW6noPD60fnBA5yHHUqiiErlyBTz4B4PDYsbTIyKC1rS1zv/8eBwcHnYMTQgiRF+vXrycgIIDj4eG8WbEi8fXq0XzBAq2ODwqCP/7QVmbYsUN7GyeDGUQu5I2cJZk2DW7eJK1tW7p//TVngInjx+Pn56d3ZEIIIR4iPT2dSZMm8cEHH1BBKU4WK0bZ+HgM8fFQvjxMnw59+96d1FeaU0UeSCJnKc6d0zq7AtPKlOHMmTMEBAQwZswYnQMTQgjxMAkJCfTu3ZtNmzbRFvifoyNlEhO1X9rYwI8/QnCwrjEKyySJnKWYOBGSk0kIDmbc6tUUK1aMRYsWYW9vr3dkQgghcnHu3Dk6derExaNH+cHBgT7JydqUIsWLQ1qa1geuaVO9wxQWSvrIWYKoKFi4EGxt+W9GBgCDBw/Gy8tL58CEEELk5q+//qJpYCBeR49y3NZWS+IcHGDKFDh/XusDJ/3gxGOQ6UcsQUgI/O9/XAkJoeKqVRQvXpyTJ09SpUoVvSMTotCwpnvems6lKNu+fTvvdunC9H/+4anMja1awddfg5ubnqGJQkimH7FW+/fD//4HJUrw7r/9KQYPHixJnBBCFGIrli1jf58+7MnIwBZQNjYYZs6EIUO0PnFCFBC5mgozpbTlWICLzz3Hos2bKVGiBKP+XV9VCCFE4bNo/Hgq9OrFJ/8mcQAGW1to2FCSOFHg5I1cYbZlC2zbBk5OvHnxIgBDhw7FxcVF58CEEELcLyMtjbUdO/KfrVspBdwqVYqSFSpguHBBJvYVJiN95AqrjAxo1AjCwzk3dChPzJ5NyZIlOXXqFJUqVdI7OiEKHYu/5+9hTedSVKRERXEiKAj3y5cBOBUYSK1167SBDUePakmcDGgQucjvfS/veAurlSshPByqVOGN6GgAhg0bJkmcEEIUJhkZ3PngA5SnJ+6XL3PZYODwuHHU2rMHKlTQkrfAQEnihMnIG7nCKDVVe3qLjubkyJHU/vhjSpUqxenTp6lQoYLe0QlRKFn0PX8fazoXq3buHMnPPYfD3r0AXDcYOLd2Ld5duugcmLBEFvdGbuTIkbi7u+Pr60tISAg3b940/m7q1KnUrVsXd3d3Nm/ebNy+ceNG6tevj5ubGx999JEeYZvHwoUQHQ116/J6RAQAr7/+uiRxQhQiUocVcUuXku7lhcPevWT+6S1ja4u31NPC3JROQkNDVXp6ulJKqVGjRqnRo0crpZQ6evSo8vX1VampqerUqVOqdu3aKiMjQ6Wnp6vatWur06dPq5SUFOXj46OioqJyPL6Op/Z4bt1SqmpVpUD9/cEHClClS5dWV65c0TsyIQo1c9/zpqzDLLb+KgoSEpTq00cpbV4B9SuoEyVKqAx7e6V8fJS6eVPvCIWFyu99r9sbuXbt2mHz7zDswMBAYmNjAVi7di29evXCzs6OmjVrUrduXfbv38/+/fupW7cuNWrUwN7enl69erFmzRq9wjedTz+FCxfAx4fXt28H4I033qB8+fI6ByaEuJfUYUVMYqK23rWXF/z4I7eAQcDcp5+m8qlTGHbskBUahC4KxWCHb7/9ls6dOwNw/vx5qlevbvxdtWrVOH/+/APbXV1dOX/+vNljNamzZ7U1VYE78fH8vmULjo6OvP322zoHJoTIjdRhVu7qVahdG15/Hc6fZz/gCzBwIKt//pmSLi4yoEHoxqTzyLVv3564uDjjZ6UUBoOBKVOm0LVrVwCmTJmCvb09vXv3Nu5zP4PBQMa/a4zevz03EyZMMP4cFBREUFBQPs7CjL76Spt2BLC7eBFPoP3w4Tg7O+sblxCFUFhYGGFhYSYtQ886zOLqL2t18iR06QLx8QCkASOA/5s4kXHjxj3075AQOSmoOsykiVxoaGiuv1+8eDHr16/nt99+M25zdXXl3Llzxs+xsbFUrVoVpRRnz559YHtu7q0ILcKZMwBk2NhwNCODc46OvPXWWzoHJUThdH9yM/Hft9kFSc86zOLqL2u0fDkMHAg3b5L274jCSGDQF1/Qb9gwvaMTFq7A6rCC6qT3qDZs2KA8PDwe6MSf2VE4OTlZnTx50thROC0tzdhRODk5Wfn4+KjIyMgcj6/jqeXfk08qBWpqvXqqNKj3339f74iEsBjmvudNWYdZZP1lTW7fVmrQIOOAhp0uLsoVVEsHB7V+2TK9oxNWKr/3vW5LdL3++uukpKTQvn17QOssPGfOHDw8PHjuuefw8PDA3t6eOXPmYDAYsLW15csvvyQ4OJiMjAwGDBiAu7u7XuEXvAsX4ORJ0kqUYOzff1O6bFnefPNNvaMSQuRA6jArdeAA9OoFJ0+iHBz42MWF0WfPUqFCBT7+5ReaNGmid4RCZCETAhcWy5ZBr17sL1eOJgkJTJw4kfHjx+sdlRAWw+Lu+VxY07lYlPnz4dVXQSky7O3pVbEiKy5coFatWmzcuBE3Nze9IxRWzOImBBb32bkTgLUJCTg5OTF8+HCdAxJCiCIiJQWGDYNBg7TGVCAtNZWzFy7g7+/Pnj17JIkThZYkcoXFv4ncTuDtt9+mbNmy+sYjhBBFQWwstGoFs2eDvT0plSqRDEQCVdq2JSwsDBcXF72jFCJH0rRaGFy/jnJ2JlUpKhUrxsmLF2XKESEekUXd8w9hTedSqIWFwfPPw+XLUL06Z6dPp/XgwVSMj+fJLl1Y/L//YW9vr3eUooiQplVLtns3BqU4ADzds6ckcUIIYUpKweTJ0LatlsS1bcvFX36h5dtvczI+ntJt2/LtihWSxAmLoNuoVXFXxvbt2KA1qw4cOFDvcIQQwnrduQP9+sGKFdrnSpW4Om8ebbt25cyZMzRp0oSff/6Z4sWL6xunEHkkTauFwDV3d5yPHWNQ1arMi42VmcKFyAdLuucfxprOpVC5cAG6d9emGPmXsrdnQJ06LIyKwtPTk+3bt8va1kIX+b3v5Y2c3u7cwfHvv8kAPAcNkiROCCFM4eBB6NZNS+aeeAKKF0edOsWJYsVYERVFzZo12bx5syRxwuJIHzmdxf/yC/ZK8SfQe/BgvcMRQgjrkpgIH3wAzZtrSVyLFnDwIGl79zK6aVP8bt2idOXKbNmy5aHLPgpRGMkbOZ0d/eorgoALtWvjU6mS3uEIIYT1uHkT3NwgLk77/OKLMH8+GXZ2vNK/P4t37MDJyYnNmzdTu3ZtfWMVIp8kkdNRRkYGtr//DkDV55/XORohhLAiKSnw3HN3kzhbW3jtNZS9PW+NGMHixYspWbIk69evx9vbW99YhXgM0rSqo62bNuGblASA95AhOkcjhBBWIiEBOnSATZvAYAA7O/DyAi8vJk+ezMyZM7G3t2f16tU0bdpU72iFeCzyRk5HWz79lPbANWdnnKtV0zscIYSwfGfOQKdOEBUFVapo61jb24OnJ18sWsT48eOxsbHhxx9/JDg4WO9ohXhsksjpJC4ujvSwMAAc2rXTNxghhLAGO3ZAjx5w7Rp4esL69doIVeD777/njTfeAODrr7+mZ8+eekYqRIGRRE4nixcvpllGBgClOnTQORohhLBwa9ZoSZxSUKoUbNgA1asDsG7dOl566SUAPvnkEwYMGKBjoEIULOkjpwOlFN/Mn0/zzA0tWugZjhBCWLZVqyAkREviQBvocP48AGFhYfznP/8hPT2dMWPG8M477+gYqBAFTxI5HWzfvh2bmBgqAcrFBerU0TskIYSwTAsXaqNT09OhQgWtP5yHB3h6cvDgQZ555hmSk5N57bXXmDJlit7RClHgJJHTwfz588l8B2do0UIbVSWEEOLRzJgB/ftDRga8/z6cOKH1k9u5k6jYWDp27EhiYiK9evXiyy+/lJVzhFWSRM7Mrl69yqpVq4yJnDSrCiHEI1IKxoyBESO0zzNmwIQJUKYMBAZy5to1goODuXr1Kp06dWLx4sXY2trqGrIQpiKJnJl99913JCcnE1yihLZBEjkhhMg7pbQEbto07XP16tpbuX9dvnyZ9u3bExsbS/PmzVm5ciXFihXTKVghTM+gVGbvUOtiMBgobKemlMLLy4sbkZHEgvb0eO2aNuO4EOKxFMZ7Pr+s6VwKlFLw7rvw2Wd3t9nba82pgYHcuHGDoKAgDh8+jK+vL9u2bcPJyUm/eIV4BPm97+WNnBnt2bOHyMhIupQpo21o1kySOCGEyAul4K23tCTOzg5q1swysOH27dt06dKFw4cPU7duXTZu3ChJnCgSJJEzo/nz5wPQ78kntQ3SrCqEEA9386Y2MnXGDC15+9//4I8/jAMbUosXp2fPnuzatYtq1aoRGhqKi4uL3lELYRYyIbCZ3Llzh+XLlwPgf/u2tlESOSGEyN3Nm/Dkk3D1qvb5hx+ga1ft58BAAEaOGMGGDRuoUKECoaGh1KhRQ6dghTA/eSNnJtu3b+f27dsENWiAw/HjUKwYNGqkd1hCCFF4KQWDB99NEOXv3AAAIABJREFU4uzsjKs1ZFq3bh0zZszAzs6OdevW4e7urkOgQuhHEjkz2bBhAwD969XTNjRuDMWL6xiREEIUch98AD/+qP1sZ6etn+rpafx1bGyscemtadOmEfjvGzohihJpWjWT9evXA9Da3l7bIM2qQgiRs88+0yb5tbHRVm9wc9OSOEdHANLS0ujTpw/Xrl2jU6dOjMicU06IIkYSOTOIiYkhJiYGJycnqp04oW2URE4IIbI3YwZkron67bfw4osP7PLBBx+wc+dOqlSpwuLFi7GxkQYmUTTJlW8Gmc2qXdq0wXDokPaE2ayZzlEJIUQhNHv23RUbqlWDZ599YJdt27bxwQcfYDAY+OGHH6hYsaKZgxSi8JBEzgwyE7m+depAWhr4+EDZsjpHJYQQhcy8eTBs2N3Ply/D0aNZdomPj+eFF15AKcW4ceNo3bq1mYMUonCRRM7E7ty5w7Zt2wB4KiND2yjNqkIIkdXs2fDaa9rPVapkmew3U0ZGBv369ePixYu0aNGCcePG6RSsEIWHJHImFhYWRlJSEv7+/pSOiNA2SiInhBB3zZhx903cjBnw99/GyX4zBzcAfP7552zYsAFnZ2d+/PFH7Oykm7cQksiZWGaz6tPBwbBnj7ZREjkhhNBMnny3T9zs2TB8uJa8BQZmSeL279/PmDFjAFi0aBGurq56RCtEoSOJnIllJnIhTz4Jt29D3bogS8cIIYTWJy6zedTVFf7v/7Ld7caNG/Tq1Yu0tDTefPNNumau7CCEkETOlKKjo4mJiaFcuXJ4Xb+ubZS3cUIIAbt2ZR3YEBf3wMAGAKUUAwcO5NSpU/j7+zNt2jQzBilE4SeJnAllvo0LDg7GdvdubaMkckKIou7UKejRQxvFX758tgMbMs2fP58VK1ZQunRpli1bhoODgw4BC1F4SSJnQpmJXKcOHbSnT5BETghRtJ0/D23bwpUr0KEDREdnO7AB4M8//2T48OEAzJs3jzp16ugRsRCFmkEppfQOwhQMBgN6ntqdO3dwdnYmKSmJ+O3bqdCqlTak/vx5MBh0i0sIa6X3PV+QrOlcsrh+HZ54AhITwcEBYmK0vnHZuHXrFo0aNSIqKor+/fuzYMECMwcrhHnl976XN3Imcu+0IxWiorSNLVpIEieEKLqGDtWSOID0dIiNzXHX4cOHExUVhbu7O7NmzTJTgEJYHt0SuZEjR+Lu7o6vry8hISHcvHkTgDNnzlCyZEn8/f3x9/dnyJAhxu+Eh4fToEED3NzcePPNN/UKPU/Wr18PQOfOnbUmA5BmVSGsiLXXYQXu++/hxx+1n+3stP5w2fSJA/jpp59YsGABDg4OLFu2jFKlSpkxUCEsjNJJaGioSk9PV0opNWrUKDV69GillFKnT59W3t7e2X6ncePGat++fUoppTp16qQ2btyY4/F1PDWllFK1a9dWgNq9e7dSTzyhFCh1+LCuMQlhzcx9z5uyDtO7/ipwBw4o5eCg1YOffabUnj1K3byZ7a7R0dHK0dFRAWru3LlmDlQI/eT3vtftjVy7du2wsdGKDwwMJPaeV+wqmzbiS5cukZiYSOPGjQF48cUX+fnnn80T7COKjo7mxIkTlCtXjiZVqsDZs9raql5eeocmhCgg1lyHFaiYGOjUCZKTYdAgbfLf+yb7zZSSkkKvXr1ITEykZ8+evPrqqzoELIRlKRR95L799ls6depk/Hz69GkCAgJo3bo1u/4d7Xn+/PksM3m7urpy/vx5s8eaF1mmHfn9d23jU0+Bra2OUQkhTMXa6rACExcHDRpoI1RLloQPP8y1n/Do0aM5dOgQNWvWZP78+RikT7EQD2XSherat29PXFyc8bNSCoPBwJQpU4wzc0+ZMgV7e3v69OkDQNWqVTl79izlypUjPDyc7t27ExkZme0T7sNu8gkTJhh/DgoKIigo6PFPKg+M04506iT944QwkbCwMMLCwkxahp51mF71V4FJT4eePeHOHe1zaqo21Uj58tnu/ssvvzB9+nTs7OxYunQpTk5OZgxWCPMrsDqswBp382HRokWqWbNmKikpKcd9goKC1KFDh9TFixdV/fr1jdt/+ukn9dprr+X4Pb1O7datW8rBwUEB6tKlS0p5eGj9Qnbt0iUeIYoKPe55U9VhOlfNjy8jQ6nBg7W6z8ZGKTs7pXx8cuwXd+7cOVW+fHkFqI8//tjMwQpROOT3vtetaXXjxo18/PHHrF27NstM3VeuXCEjIwOAkydPEhMTw5NPPknlypUpU6YM+/fvRynFkiVL6Natm17h5ygsLIzk5GQCAgJwsbODyEhtvqSGDfUOTQhRgKy1DisQH30Ec+dqdd/69VrLRDYT/gKkpaXxwgsvcPXqVTp06MDbb7+tQ8BCWC6TNq3m5vXXXyclJYX27dsDWmfhOXPmsGPHDsaPH4+9vT22trbMmzfP+Ip9zpw5vPTSSyQlJdG5c2c6duyoV/g5ytKsmrmaQ5MmWoUmhLAa1lqHPbZvvoExY7Sfv/9eW70hF59++ik7duygcuXKLFmyxDiARAiRN7KyQwHz8PAgKiqKHTt20GLNGvjsM/jvf2HyZLPHIkRRYk2rIVjsuRw5An5+oBRUrQrHjmX7Fi7ThQsXcHNz49atW2zatIng4GAzBitE4SIrOxQCly5dIioqipIlS9KkSZO7Ax1attQ3MCGEMDWlYMAA7f8B4uPh6NFcv/Lf//6XW7du0b17d0nihMgn3ZpWrdH27dsBeOqppyiWkgKHDoGNDTRtqnNkQghhYgsXanWera1W73l45LhyA8ChQ4dYvHgx9vb2fPLJJ2YMVAjrIolcAdq2bRsArVu3hr17teH3AQG5Ni0IIYTFi46G4cO1n7/6Spv83NMzx7pPKcWIESNQSjF8+HDq1KljxmCFsC6SyBWgLIncv4MeZP44IYRVS0yERo3gn3+0xO2556BMmVy/smrVKnbu3EmFChUYO3asmQIVwjpJH7kCcuHCBY4fP07p0qUJCAiQiYCFEEVDWBjcuKH9fOeONuVSLpKSkhg5ciQAH3zwAWXLljVxgEJYN0nkCkjm27gWLVpgr5TWtArQvLmOUQkhhIkFBWnNqHZ22v/n0i8OYObMmZw6dQovLy9eeeUV88QohBWTptUCkqVZNTxcezKtVw8qVdI5MiGEMCFHR9izRxuhmku/ONBG9k+ZMgWAzz//HDs7+RMkxOOSu6iAZEnk/v1ZmlWFEEWCoyMEBj50t3HjxpGYmEiXLl2MEykLIR6PNK0WgLNnz3Ly5EnKli2Ln5+f9I8TQoj7HD58mAULFmBnZ8enn36qdzhCWA1J5ApA5tu4li1bYmsw3F2aSxI5IYTIMt3IsGHDqFevnt4hCWE1JJErAFmaVSMjISEBqlWDmjX1DUwIIQqBNWvWEBYWhrOzM+PHj9c7HCGsiiRyj0kplTWRu7dZ1WDQMTIhhNBfcnIy77zzDgATJ06kXLlyOkckhHWRRO4xnTp1irNnz+Ls7EyDBg2kf5wQQtzjyy+/5MSJE7i7u/Pqq6/qHY4QVkcSuceU+TauVatW2BgMksgJIcS/4uPjmTRpEqBNN2Jvb69zREJYH0nkHlOWZtUzZyA2FsqVe+ikmEIIYe3Gjx/PzZs36dixIx07dtQ7HCGskiRyjyHH/nFPPQU28k8rhCi6/vrrL77++mtsbW357LPP9A5HCKsl2cZjiI6O5sKFC1SsWBFPT09pVhVCCO5ON5KRkcHgwYPx8PDQOyQhrJYkco8h821cUFAQBukfJ4QQAPz6669s2bIFJycnJkyYoHc4Qlg1SeQeQ5Zm1fh4OHYMSpSAgACdIxNCCH2kpqby9ttvA/D+++9Tvnx5nSMSwrpJIpdPSinCwsKAfxO5zNUcmjSBYsX0C0wIIXQ0Z84cjh8/jpubG0OGDNE7HCGsniRy+RQVFUVcXByVK1fWlpvJbFZt2VLfwIQQQidXr141NqV+9tlnFJOHWiFMThK5fLq3WdVgMMCOHdovpH+cEKKImjBhAtevX6ddu3Y8/fTTeocjRJEgiVw+Zekfl5gIERFgawuBgTpHJoQQ5hcVFcXcuXOxsbHh888/1x5whRAmJ4lcPmRkZGTtH7dnD2RkgL8/lC6tb3BCCKGDt99+m/T0dAYNGoS3t7fe4QhRZEgilw9//fUXV69exdXVldq1a8u0I0KIIm3jxo1s2LCBMmXKGJfkEkKYh53eAViikiVLMmzYMJycnGT+OCFEkefn58fAgQOpX78+FStW1DscIYoUg1JK6R2EKRgMBsxyasnJ4OQESUnaXHIVKpi+TCHEA8x2z5uBNZ2LECJv8nvfS9Pq4zp0SEvi3N0liRNCCCGEWUki97ikWVUIIYQQOpFE7nFJIieEEEIInUgfuceRkQHly8P163D6NNSoYdryhBA5sqZ+ZdZ0LkKIvJE+cnr46y8tiateXZI4IYQQQpidJHKPQ5pVhRBCCKEjSeQehyRyQgghhNCRJHL5pZQkckIIIYTQlSRy+XXqFFy4AM7O2hxyQgghhBBmJolcfmW+jWveHGzkn1EIIYQQ5qdrBjJ+/Hh8fHzw8/OjY8eOXLp0yfi7N954g7p16+Lr68vhw4eN2xcvXoybmxv16tVjyZIleoStua9ZNSwszKzFS3mWXZ4eZVp7eeZm0fXXIyps/y0LWzxQ+GKSeHJX2OJ5HLomciNHjuTIkSNERETw9NNPM3HiRADWr1/PiRMniI6OZt68ebz22msAJCQkMGnSJA4cOMC+ffuYOHEiN27c0Cd4SeSkPAsr09rLMzeLrr8eUWH7b1nY4oHCF5PEk7vCFs/j0DWRK126tPHnW7duYfNvE+XatWt58cUXAWjSpAk3btwgLi6OTZs2ERwcTNmyZXFyciI4OJiNGzeaP/ATJ+D4cShRAvz9zV++EEJ3Flt/CSGsip3eAYwdO5YlS5bg5OTEtm3bADh//jzVq1c37uPq6sr58+cf2F6tWjXOnz9v3oATE6FtW+1nGxtISgJ7e/PGIIQoFCyu/hJCWB2TL9HVvn174uLijJ+VUhgMBqZMmULXrl2N2z/66CPu3LnDhAkT6NKlC++99x7NmjUDoF27dnzyySds3bqVlJQU3nvvPQAmT55MqVKlGDFixIMnZjCY8rSEEIVQQVdnUn8JIcwpP3WYyd/IhYaG5mm/3r1706VLFyZMmICrqyvnzp0z/i42NpaqVavi6uqapV07NjaW1q1bZ3s8WadQCPG4pP4SQhR2uvaRi4mJMf68Zs0a6tevD8AzzzxjHNG1d+9enJyccHFxoUOHDoSGhnLjxg0SEhIIDQ2lQ4cOusQuhCjapP4SQhQGuvaRGz16NMePH8fGxoYaNWrw1VdfAdC5c2fWr19PnTp1KFWqFAsXLgSgXLlyjBs3joYNG2IwGHj//fdxcnLS8xSEEEWU1F9CiMLA5H3khBBCCCGEaVj8kgQDBgzAxcWFBg0aGLclJCQQHBxMvXr16NChQ4HP1ZRdmSNHjsTd3R1fX19CQkK4efOmScvL9Omnn2JjY8O1a9dMXt4XX3xB/fr18fb2ZvTo0SYt78iRIzRt2hQ/Pz8aN27MwYMHC6y82NhY2rRpg4eHB97e3syaNQsw3XVzf3lffPEFYLprJqfzy1TQ10xu5ZnqmsmpTFNeN6aUl2vvyJEjNGvWDG9vb3x9fVm+fHmBx7Fx40bq16+Pm5sbH3300QO/T0lJoVevXtStW5emTZty9uzZAo/hUeKZPn06np6e+Pr60r59+yx9E/WIJ9PKlSuxsbEhPDzcpPHkNably5fj6emJt7c3ffv21TWec+fO0aZNG/z9/fH19WXDhg0mjSe3v5+ZcprAW494fvzxR3x8fPD19aV58+b8+eefDz+osnA7d+5UERERytvb27ht5MiR6qOPPlJKKTVt2jQ1atQok5cZGhqq0tPTlVJKjRo1So0ePdqk5Sml1Llz51SHDh1UzZo11dWrV01a3rZt21T79u1VamqqUkqp+Ph4k5YXHBysNm3apJRSav369SooKKjAyrt48aKKiIhQSimVmJio3NzcVFRUlMmum5zKM9U1k1N5SpnmmsmpPFNeM/eXWa9ePRUZGWnS68aU8nLtRUdHq5iYGKWUUhcuXFBVqlRRN27cKLAY0tPTVe3atdXp06dVSkqK8vHxMV43mebMmaMGDx6slFJq6dKl6vnnny+w8vMTT1hYmLpz545SSqm5c+fqHo9S2vXYsmVL1bRpU3Xo0CGTxZPXmKKjo5W/v7/xWinI+zA/8QwaNEh99dVXSimlIiMjVc2aNU0Wj1I5//3MtH79etW5c2ellFJ79+5VTZo00TWePXv2qOvXryullNqwYUOe4rH4N3LNmzenXLlyWbatWbOGfv36AdCvXz9+/vlnk5fZrl0744SggYGBxMbGmrQ8gBEjRvDJJ58UWDm5lTd37lxGjx6NnZ3WrbJChQomLc/Gxsb4VuL69etUq1atwMqrXLkyvr6+gDapq7u7O7GxsSa7brIr7/z58ya7ZnIqD0xzzeRUnimvmfvLrF+/PhcuXDDpdWNKebn26tSpQ+3atQGoUqUKlSpVIj4+vsBi2L9/P3Xr1qVGjRrY29vTq1cv1qxZk2OcPXv2ZOvWrQVWfn7iadWqFcWLFwe0e8iU8/LlJR6AcePGMWrUKBwcHEwWy6PENH/+fIYOHUqZMmWAgr0P8xOPjY2NsfXBHPdoTn8/M61ZsybbCbz1iicwMJCyZcsaf87LNW3xiVx2Ll++jIuLC6BV+AVZ2eXFt99+S6dOnUxaxrp166hevTre3t4mLSfT8ePH2bFjB4GBgbRu3drkTVbTp0/nnXfe4YknnmDkyJFMnTrVJOWcPn2aw4cPExgYSFxcnMmvm8zymjRpkmW7qa6Ze8szxzVzb3nmumbuLdNc101Be9Q6a//+/aSmphoTu4KQ00TGOe1ja2uLk5NTgXbreNR47rVgwQKT1rt5iefw4cPExsbSuXNnk8XxqDEdP36cv//+m+bNm9OsWTM2bdqkazzvv/8+3333HdWrV6dLly7GriZ6KcwTdX/zzTd5uqZ1X9nB2kyZMgV7e3v69OljsjLu3LnDlClTssxxpUw8ZiUtLY3r16+zd+9eDhw4wHPPPcfJkydNVt7cuXOZOXMm3bt3Z+XKlfTv3z/Pc3rl1T///EPPnj2ZOXMmpUuXNvkkrPeXl8lU18y95dna2pr8mrn//Mxxzdxfpjmum/zKaXLhyZMnP9JxLl68yIsvvsh3331XoPFldz3cf0/cv0/mOZhCXuLJ9P3333Po0CG2b99ukljyEo9SihEjRrB48eJcv2POmECru2NiYtixYwdnz56lRYsWHD161PiGztzx/PTTT7z88suMGDGCvXv30rdvX44ePVrgseTVo1xn5rRt2zYWLlzIrl27HrqvVb6Rc3FxMVaYly5dolKlSmYpd/Hixaxfv54ff/zRpOWcOHGC06dP4+PjQ61atYiNjSUgIIDLly+brMzq1avz7LPPAtCoUSNsbGy4evWqycpbvHgx3bt3B7QmnP379xfo8dPS0ujZsyf/93//R7du3QDTXjfZlQemu2buL8/U10x252fqaya7Mk193TyO0NBQ/vjjD+P//vzzT/744w+eeeaZPF97iYmJdOnShQ8//JBGjRoVaHyurq5ZBi9kTmR8r+rVqxsHFKSnp3Pz5s1cm4lMHQ/Ali1bmDp1KuvWrcPehMslPiyexMREjh49SlBQELVq1WLv3r1069bNpAMe8vJv5OrqSrdu3bCxsaFmzZrUq1eP6Oho3eJZsGABzz33HKA1HSYlJXHlyhWTxJMXOU3grac//viDQYMGsXbt2jzdX1aRyCmlsmTVzzzzDIsWLQK0iv3eP5ymKnPjxo18/PHHrF271iR9I+4tz8vLi0uXLnHy5ElOnTqFq6srERERBZp43H9+3bt3N/aHOX78OKmpqZQvX95k5VWrVs34dL1161bc3NwKrCyA/v374+HhwfDhw43bTHndZFeeKa+Z+8sz9TWT3fmZ+prJrkxTXzemkpdrLzU1le7du9OvXz9jglyQGjVqRExMDGfOnCElJYWlS5fyzDPPZNmna9euxjdOK1asoE2bNgUex6PEExERwWuvvcbatWsL9NrKTzxlypTh8uXLxnssMDCQdevW4e/vr1tMoN2Hv/32GwBXrlwhOjqaJ598Urd4atSowZYtWwCIiooiOTnZpP324MG/L/fKaQJvveI5e/YsISEhfPfdd3nvOvHoYy4Kl969e6sqVaqoYsWKqerVq6tvv/1WXbt2TbVt21a5ubmpdu3aqYSEBJOXWadOHfXEE08oPz8/5efnZxzZZary7lWrVq0CHbWaXXmpqamqb9++ysvLSwUEBKiwsDCTlrd7924VEBCgfH19VWBgoAoPDy+w8nbt2qVsbGyUj4+P8vX1VX5+fmrDhg3q6tWrJrlusitv/fr1Jrtmcjq/exXkNZNTeSkpKSa7ZnIq05TXjSnldO0dPHhQDRw4UCml1Pfff6+KFSum/Pz8jOd85MiRAo1jw4YNys3NTdWpU0dNnTpVKaXU+PHj1bp165RSSiUlJan//Oc/qk6dOqpJkybq1KlTBVr+o8bTrl07VblyZeO/Sbdu3XSN516tW7c2+ajVvMb01ltvKQ8PD9WgQQO1fPlyXeOJjIxUTz31lPLx8VF+fn5qy5YtJo0nu78vX331lZo3b55xn6FDh6ratWurBg0amPy/2cPieeWVV5Szs7Pxmm7UqNFDjykTAgshhBBCWCiraFoVQgghhCiKJJETQgghhLBQksgJIYQQQlgoSeSEEEIIISyUJHJCCCGEEBZKEjkhhBBCCAsliZwQQgghhIWSRE4IIYQQwkJJIidydO3aNfz8/PD396dKlSq4uroaP6elpekdXrZu3LjB3LlzTVpGUlISQUFBeVoQOy4ujt69e1O3bl0aNWpEly5diImJITU1lVatWpGRkWHSWIUQwhzWrl3LxYsX9Q6jSJJETuTI2dmZiIgIwsPDGTx4MG+99Zbxs52dna6x5ZREJSQkMGfOnAI95v2+/fZbQkJCMBgMxm1xcXGEhYXx+++/Z9m3R48etGnThujoaA4cOMDUqVOJi4vD3t6edu3asXTp0nzFKkRR9/PPPxsfLP39/fHz88PW1pZNmzYVaDmOjo4PbGvdujWhoaFZts2cOZNhw4Y98rHyonnz5kD+H1Qf5eEzP+Li4li0aJHx+PKgal6SyIk8ya4C+OGHH2jSpAn+/v4MHjwYpRRnzpzB3d2dl19+mXr16tG3b1+2bt1K8+bNqVevHgcPHgQw7te3b188PDx47rnnSEpKyvW49evXp1+/fnh7exMbG0uPHj1o1KgR3t7efPPNNwCMGTOGkydP4u/vz6hRozhz5gze3t7GmD/77DMmTZpkjOH+Y2ZXdnbnff+i5pGRkQQFBWFjY8Pt27cB2LZtG8WKFWPgwIHG/by9vXnqqacA6NatGz/88EO+/5sIUZR1797d+GAZHh7OkCFDaNmyJR06dCjQcu59YMvUp08ffvrppyzbli5dSp8+fR75WHmxa9cuIP8Pqtk9fBYkFxcXfH19jZ/lQdW8JJET+XLs2DGWLVvG77//Tnh4ODY2Nsak5MSJE7z77rv8/fffHDt2jJ9++oldu3bxySefMGXKFOMx/v77b4YNG0ZkZCSOjo7MmTMn1+NGR0czbNgw/vzzT6pXr87ChQs5cOAABw4cYObMmSQkJDBt2jRq165NeHg4H330EZB75RkTE2M85q1bt3IsO1NqaiqnTp3iiSeeyLLdw8ODrVu3kpGRQcmSJQH466+/CAgIyLFsLy8vDhw48Aj/6kKI7Bw/fpxJkybx/fffA/D555/j7e1NgwYNmDlzJqA9uHl4eDBo0CC8vLzo2LEjycnJxmNk92CYk5CQEH799VdSU1ONx7548SLNmjUDsn8YvV92MQIsWbIEHx8f/Pz86NevH3D3Td79D6rjx49n1qxZxu+OHTuWL7/88oGy7n34zOvD9u3bt+nSpQt+fn40aNCAFStWcOHCBTZt2sTmzZvZvHkze/fuNZZx/znKg6r56Ns+JizW1q1bCQ8Pp1GjRiilSEpKwsXFhRYtWlCrVi08PDwA8PT0pG3btoD2NurMmTPGYzzxxBMEBgYC0LdvX2bNmoWDgwOHDh3K9rg1a9akUaNGxu/PmDGDn3/+GYDY2Fiio6NxcXF5pPOoUaOG8Zg5ndO9rly5gpOT0wPHcXFxeeSybWxscHBw4NatW5QqVeqRviuE0KSlpfHCCy/w+eefU61aNcLDw1m8eDEHDhwgPT2dJk2aEBQUhJOTEzExMSxbtoyvv/6a559/nlWrVhnfoi1cuBAnJyeSkpJo1KgRISEhlCtXLtsynZ2dady4MRs3bqRr164sXbqU559/Hsj6kGtra8vQoUP54Ycf6Nu3rzHZOXToULYx2tvbM3XqVH7//XfKlSvH9evXgbsPo9OmTePo0aOEh4cDWlL27LPP8sYbb6CUYunSpQ88HGb38HnixAlWrVqFh4cHDRs2ND5sr127lilTprB69Wo2btxItWrV+OWXXwBITEzE0dGRqlWrPvDvcfnyZY4fP85vv/1G3759AXlQNSdJ5ES+KKXo169fljdsoFUsDg4Oxs+ZyUrmz7kNkrCx0V4Qv/TSS9ke995kZ/v27fz222/s27cPBwcHWrdubWyavZednR3p6enGz/fvc+8xczqne5UoUSLbcrLj6enJypUrc90nOTmZ4sWL5+l4QogHjR07Fi8vL/7zn/8AWjNkjx49jPfVs88+y86dO+natSu1atUydrUICAjg9OnTxuNk92DYuHHjHMvt1asXS5cuNSZyCxcuBLJ/IKxcuTJwNyHbvXt3lhhDQkLYsWMHBoOBnj17GhPI7B4a71WjRg0qVKgrEZ/OAAAEYUlEQVTAkSNHuHTpEv7+/g8kn9k9fOblYdvb25t3332XMWPG8PTTTxv76WWnUqVKD7x9kwdV85GmVZEvbdu2ZeXKlcTHxwNa342zZ88CuQ8auPd3Z8+eZd++fQD89NNPNG/enDZt2uTpuDdu3KBcuXI4ODhw7Ngx4yt+R0dHEhMTjfu5uLgQHx9PQkICycnJxqfL7OLJ7ZwyOTk5kZ6eTkpKykP/jdq0aUNKSgoLFiwwbvvzzz/ZvXs3oI0KrlixIra2tg89lhDiQWFhYaxevZrZs2cbt+VW/9z7kGlra2t8sLz3wfDw4cP4+vo+9IGte/fubN26lYiICJKSkox9xDIfCMPDw4mIiCAqKopx48Zl+e79MSql8t1/7ZVXXmHhwoUsXLiQ/v37P/D77B4+8/KwXbduXQ4dOoS3tzdjx45l8uTJjxybPKiahyRyIl/c3d2ZPHkywcHB+Pj4EBwczKVLl4CsfdLur5zu/VyvXj1mz56Nh4cHCQkJDB48OM/H7dixI6mpqXh6evLee+/RtGlTQGvyaNasGQ0aNGDUqFHY2dkxbtw4GjVqRHBwMO7u7jnGk1vZ9woODjZ2Pn6Y1atXs3nzZurUqYO3tzfvvfee8el827ZtdO7cOU/HEUJklZCQQP/+/VmyZImxXypAy5Yt+fnnn0lKSuLWrVusXr2aFi1aADkneTk9GOb2nVKlStGqVSv69+9P7969jduzeyA8d+5clmPlFGObNm1YsWIF165dM3733u/d/6AKWkK5ceNGDh48mO1Aj+wePvPysH3x4kVKlChBnz59ePfdd43NuXklD6pmpITQwenTp5WXl5feYeRLRESEevHFFx/7OM8++6w6fvx4AUQkRNEzdepUVbp0aeXn56f8/PyUr6+v8vPzU8uXL1fTp09XXl5eytvbW82aNUsppdU53t7exu9/+umnauLEiUoppZKTk1WnTp2Uh4eH6tGjh2rdurXavn27UkopR0fHHGNYvXq1srGxUX///XeW7cuXL1e+vr6qQYMGqmHDhmrfvn0PHCu7GJVSasmSJcrLy0v5+vqql19++YHvvfDCC8rb21uNHDnSuO21115TY8aMyTHOV155RW3dujXbf4eXX35ZrVq16oHfbdq0STVo0ED5+vqqxo0bq0OHDuV4/OysXLlSvfPOO4/0HZE/BqVMNLGMELk4c+YMXbt25Y8//tA7lHxZtGgR/fr1y3dzSGpqKsuWLTN2DBZCiPzIyMggICCAlStXUrt27Wz3OXz4MNOnT2fx4sVmiyskJIRp06ZRt25ds5VZVEnTqtBFjRo1LDaJA21AxuPMyWRvby9JnBDisURFRVG3bl3at2+fYxIH4OvrS+vWrU02IfD9UlNT6dGjhyRxZiJv5IQQQgghLJS8kRNCCCGEsFCSyAkhhBBCWChJ5IQQQgghLJQkckIIIYQQFkoSOSGEEEIICyWJnBBCCCGEhZJETgghhBDCQkkiJ4QQQghhof4fz2B20YPSmpkAAAAASUVORK5CYII=\n"
+      ],
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f28149b01d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot Annual mean:\n",
+    "f = plt.figure(figsize=(10,5),facecolor='white')\n",
+    "ax1 = plt.subplot(1,2,1);\n",
+    "ax1.set_xlabel('Temperature ($^\\circ$C)')\n",
+    "ax1.set_ylabel('Depth (m)')\n",
+    "ax2 = plt.subplot(1,2,2)\n",
+    "ax2.set_xlabel('Zonal Velocity (ms$^{-1}$)')\n",
+    "ax2.set_ylabel('Depth (m)')\n",
+    "ax1.plot(temp_140w0n.mean('time'),-dep,'-k',label=expt,linewidth=2)\n",
+    "ax1.plot(obs_temp.mean('time'),-obs_temp.depth,'.-r',linewidth=2,label='TAO')\n",
+    "ax2.plot(u_140w0n.mean('time'),-dep,'-k',label=expt,linewidth=2)\n",
+    "ax2.plot(obs_u.mean('time'),-obs_u.depth,'.-r',linewidth=2)\n",
+    "ax1.legend(loc=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "autoscroll": false,
+    "collapsed": false,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:analysis3]",
+   "language": "python",
+   "name": "conda-env-analysis3-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  },
+  "name": "plot_TAO_140W_0N.ipynb"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Adds a script to compare temperature and zonal velocity profiles from ACCESS-OM2 to the TAO array mooring at 140W, 0N.

Note that to do this comparison properly we should either wait for the IAF run, or select only neutral ENSO periods, as I suspect the TAO array TC is smoothed somewhat by averaging over different ENSO states.

The TAO data comes from https://www.pmel.noaa.gov/tao/drupal/disdel/ and is in /g/data/e14/rmh561/TAO/t0n140w_dy.cdf and .../adcp0n140w_dy.cdf. I don't have permission to copy this to the hh5 cosima observations folder - feel free to.