### PR TITLE
Update to jupyter_vdi.py script

### DIFF
--- a/scripts/jupyter_vdi.py
+++ b/scripts/jupyter_vdi.py
@@ -41,8 +41,9 @@ OS_v = platform.release()
 
 # Check Version of MAC OS
 
-if OS_c == 'Darwin':
+is_mac == (OS_c == Darwin)
 
+if is_mac:
     import appscript
 
 import os
@@ -180,16 +181,16 @@ def start_jupyter(s):
         m = re.search('http://localhost:(?P<url>.*)',s.decode('utf8'))
         if m is not None:
             params.update(m.groupdict())
-            if not (OS_c == 'Darwin'):
-                # Open browser locally
-                webbrowser.open('http://localhost:'+params['url'])
-                webbrowser_started = True
-            else:
+            if is_mac:
                 print('using appscript',params['url'])
                 safari = appscript.app("Safari")
                 safari.make(new=appscript.k.document, with_properties={
                             appscript.k.URL: 'http://localhost:'+params['url']})
 
+                webbrowser_started = True
+            else:
+                # Open browser locally
+                webbrowser.open('http://localhost:'+params['url'])
                 webbrowser_started = True
     return s
 


### PR DESCRIPTION
I've updated the jupyter_vdi.py script to scrape the actual port used, as jupyter will hop onto another port if the specified port was in use.

As a result I've reorganised the way the script interacted with the jupyter process. I've also suppressed some of the output as it was wrong on some instances (seems the URL had two copies of the token, dunno why).

I've also added command line parsing so I could pass in a verbose flag. Fairly minimal at this stage, but thought it was worth putting in the infrastructure. Created a main routine and separate argument parsing as it makes it easier to add testing in the future.