### PR TITLE
Added date time tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no
+  - conda config --set always_yes yes --set changeps1 yes
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose matplotlib bokeh joblib xarray dask distributed pandas netcdf4 ipython
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy scipy nose matplotlib bokeh joblib xarray dask distributed pandas netcdf4 ipython
   - source activate test-environment
   - python setup.py install
 script: 

--- a/cosima_cookbook/__init__.py
+++ b/cosima_cookbook/__init__.py
@@ -17,6 +17,9 @@ from . netcdf_index import *
 from . import summary
 from . summary import *
 
+from . import date_utils
+from . date_utils import *
+
 from . distributed import start_cluster, compute_by_block
 
 __all__.extend(netcdf_index.__all__)

--- a/cosima_cookbook/date_utils.py
+++ b/cosima_cookbook/date_utils.py
@@ -1,0 +1,176 @@
+
+#!/usr/bin/env python
+
+"""
+Copyright 2018 ARC Centre of Excellence for Climate Systems Science
+author: Aidan Heerdegen <aidan.heerdegen@anu.edu.au>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import print_function
+
+import xarray as xr
+import cftime
+import numpy as np
+
+rebase_attr = '_rebased_units'
+rebase_shift_attr = '_rebased_shift'
+bounds = 'bounds'
+boundsvar = 'bounds_var'
+
+# Code adapted from https://github.com/spencerahill/aospy/issues/212
+
+def rebase_times(values, input_units, calendar, output_units):
+    dates = cftime.num2date(values, input_units, calendar)
+    return cftime.date2num(dates, output_units, calendar)
+
+def is_bounds(var):
+    """
+    Return True if the xarray variable has been flagged as a bounds
+    variable (has a bounds_var attribute)
+    """
+    return boundsvar in var.attrs
+
+def set_bounds(var, varname):
+    """
+    Set the bounds_var attribute to the name of the dimension for which
+    it is the bounds
+    """
+    var.attrs[boundsvar] = varname
+
+def flag_bounds(ds):
+    """
+    Cycle through all the variables in a dataset and mark variables which
+    are bounds as such by adding a bounds_var attribute
+    """
+    for name in ds.variables:
+        if is_bounds(ds[name]):
+            # This is a bounds variable and has been flagged as such
+            continue
+        if bounds in ds[name].attrs:
+            # Flag bounds variable as such
+            set_bounds(ds[ds[name].attrs[bounds]],name)
+
+def unflag_bounds(ds):
+    """
+    Cycle through all the variables in a dataset and unflag variables which
+    are bounds by deleting any bounds_var
+    """
+    for name in ds.variables:
+        try:
+            del(ds[name].attrs[boundsvar])
+        except KeyError:
+            pass
+
+def rebase_variable(var, calendar=None, target_units=None, src_units=None, offset=None):
+    """
+    Create rebased time variable
+    """
+    attributes = var.attrs
+
+    # If no target_units are specified check if the variable has been previously
+    # rebased and use this as the target, which will undo the previous rebasing
+    if calendar == None:
+        try:
+            calendar = var.attrs['calendar']
+        except KeyError:
+            try:
+                calendar = var.encoding['calendar']
+            except KeyError:
+                raise AttributeError('No calendar attribute found and none specified')
+
+    # Default to src_units being the units for the variable (bounds variables
+    # may not have correct units so in this case it has to be specified)
+    if src_units is None:
+        src_units = attributes["units"]
+
+    # If no target_units are specified check if the variable has been previously
+    # rebased and use this as the target, which will undo the previous rebasing
+    if target_units == None:
+        try:
+            target_units = attributes[rebase_attr]
+        except KeyError:
+            raise AttributeError('No existing rebase found and target_units not specified')
+        finally:
+            del attributes[rebase_attr]
+    else:
+        attributes[rebase_attr] = src_units
+
+    # Rebase
+    newvar = xr.apply_ufunc(rebase_times, var, src_units, calendar, target_units)
+
+    if rebase_shift_attr in attributes:
+        newvar = newvar - attributes[rebase_shift_attr]
+        del attributes[rebase_shift_attr]
+    else:
+        if offset is not None:
+            try:
+                offset = cftime.date2num(offset,src_units,calendar)
+            except AttributeError:
+                pass
+            newvar = newvar + offset
+            attributes[rebase_shift_attr] = offset
+
+    if  newvar.min() < 0:
+        raise ValueError("Rebase creates negative dates, specify offset to shift dates appropriately")
+    # offset = num2date(0,trg_units,calendar) - (0,src_units,calendar)
+    # if offset > 0:
+    #     newvar[:] = newvar.values + offset
+    #     attributes[rebase_shift_attr] = -offset
+
+    # Save the values back into the variable, put back the attributes and update
+    # the units
+    newvar.attrs = attributes
+    newvar.attrs['units'] = target_units
+
+    return newvar
+
+def rebase_dataset(ds, target_units=None, timevar='time'):
+    """
+    Rebase the time dimension variable in a dataset to a different start date.
+    This is useful to overcome limitations in pandas datetime indices used in 
+    xarray, and to place two datasets with different date indices onto a common
+    date index
+    """
+
+    # The units are defined as the units used by timevar
+    units = ds[timevar].attrs['units']
+    calendar = ds[timevar].attrs['calendar']
+
+    newds = ds.copy()
+
+    # Cycle through all variables, setting a flag if they are a bounds variable
+    flag_bounds(newds)
+
+    for name in newds.variables:
+        if is_bounds(newds[name]):
+            # This is a bounds variable and has been flagged as such so ignore
+            # as it will be processed by the variable for which it is the bounds
+            continue
+        if newds[name].attrs['units'] == units:
+            newds[name] = rebase_variable(newds[name], calendar, target_units)
+            if bounds in newds[name].attrs:
+                # Must make the same adjustment to the bounds variable
+                bvarname = newds[name].attrs[bounds]
+                newds[bvarname] = rebase_variable(newds[bvarname], calendar, target_units, src_units=units)
+
+    # Unset bounds flags
+    unflag_bounds(newds)
+
+    # newds = xr.decode_cf(newds, decode_coords=False, decode_times=True)
+
+    return newds
+
+def shift_time(ds):
+    """
+    Apply time shift to un-decoded time axis, to align datasets and 
+    """
+    pass

--- a/test/test_dates.py
+++ b/test/test_dates.py
@@ -129,10 +129,10 @@ def test_matching_time_units():
 
     # A different offset will yield a different dataset, but upon rebasing a second time
     # should still be the same as the original regardless of offset.
-    ds1 = rebase_dataset(ds, target_units,offset=timedelta(days=200*365))
-    ds3 = rebase_dataset(ds1)
+    ds3 = rebase_dataset(ds, target_units,offset=timedelta(days=200*365))
+    ds4 = rebase_dataset(ds3)
 
-    assert(ds.equals(ds3))
-    assert(not ds2.equals(ds3))
+    assert(ds.equals(ds4))
+    assert(not ds1.equals(ds3))
 
 

--- a/test/test_dates.py
+++ b/test/test_dates.py
@@ -20,22 +20,88 @@ import pytest
 import sys, os, time, glob
 import shutil
 import pdb # Add pdb.set_trace() to set breakpoints
+import xarray as xr
+import numpy as np
+import cftime
+
+from cosima_cookbook.date_utils import rebase_times, rebase_dataset, \
+    rebase_variable, rebase_shift_attr
+
+from xarray.testing import assert_equal
 
 verbose = True
+
+times = []
 
 def setup_module(module):
     if verbose: print ("setup_module      module:%s" % module.__name__)
     if verbose: print ("Python version: {}".format(sys.version))
     # Put any setup code in here, like making temporary files
+    # Make 5 years of a noleap calendar on the first of each month
+    global times
+    for y in range(1,6):
+        for m in range(1,13):
+            times.append(cftime.date2num(cftime.datetime(y,m,1),units='days since 01-01-01',calendar='noleap'))
+    times = np.array(times)
  
 def teardown_module(module):
     if verbose: print ("teardown_module   module:%s" % module.__name__)
     # Put any taerdown code in here, like deleting temporary files
 
-def test_something():
+def test_rebase_times():
 
-    # Put tests in functions which begin with 'test_'
+    # Should be a 10 year offset between original times and rebased times
+    assert(not np.any((times + 365*10) - rebase_times(times,'days since 1980-01-01','noleap','days since 1970-01-01')))
 
-    # User assert to test conditions
-    assert(True)
+    # Should be a -10 year offset between original times and rebased times
+    assert(not np.any((times - 365*10) - rebase_times(times,'days since 1980-01-01','noleap','days since 1990-01-01')))
+
+def test_rebase_variable():
+
+    timesvar = xr.DataArray(times,attrs={'units':'days since 1980-01-01','calendar':'noleap'})
+
+    print("att:",timesvar.attrs)
+
+    # Test we can rebase with and without explicitly setting a calendar
+    timesvar_rebased = rebase_variable(timesvar, target_units='days since 1970-01-01')
+    assert(timesvar_rebased.equals(rebase_variable(timesvar, 'noleap', target_units='days since 1970-01-01')))
+
+    assert(not timesvar.equals(timesvar_rebased))
+
+    # Should be a 10 year offset between original times and rebased times
+    assert(not np.any((times + 365*10) - timesvar_rebased.values))
+    # assert(not np.any((times + 365*10) - rebase_variable(timesvar, 'noleap', target_units='days since 1970-01-01').values))
+
+    with pytest.raises(ValueError):
+        timesvar_rebased = rebase_variable(timesvar, 'noleap', target_units='days since 1990-01-01')
+
+    # Rebase with an offset otherwise would have negative dates
+    timesvar_rebased = rebase_variable(timesvar, 'noleap', target_units='days since 1990-01-01', offset=365*10)
+
+    # Values should be the same
+    assert(not np.any(times - timesvar_rebased.values))
+
+    # But the rebase_shift_attr should be set to 10 years
+    assert(timesvar_rebased.attrs[rebase_shift_attr] == 365*10)
+
+    # Check we get back timesvar if rebased again with no arguments (rebases to previous
+    # units and applies offset if required in this instance)
+    assert(timesvar.equals(rebase_variable(timesvar_rebased)))
+
+
+def test_matching_time_units():
+
+    testfile = 'test/data/ocean_sealevel.nc'
+
+    ds = xr.open_dataset(testfile,decode_times=False)
+    target_units = 'days since 1800-01-01'
+
+    ds1 = rebase_dataset(ds, target_units)
+    ds1.to_netcdf('tmp.nc')
+
+    ds2 = rebase_dataset(ds1)
+    ds2.to_netcdf('tmp2.nc')
+
+    assert(ds.equals(ds2))
+
 


### PR DESCRIPTION
Some solutions were needed to address calendar issues as discussed in Issue https://github.com/OceansAus/cosima-cookbook/issues/86.

This is some utility code that can be used to shift time series to new origins and back again relatively painless (hopefully). 

These are infrastructure routines that can be incorporated into other existing routines like get_ncvariable, but I have not done this yet.